### PR TITLE
docs: Claude Code 소스코드 한국어 분석 문서 (19개 문서, 6,926줄)

### DIFF
--- a/docs/ko/level-2-systems/permission-system.md
+++ b/docs/ko/level-2-systems/permission-system.md
@@ -360,6 +360,6 @@ type PermissionDecisionReason =
 
 ## Navigation
 
-- 이전: [Tool 시스템](tool-system.md)
+- 이전: [커맨드 시스템](command-system.md)
 - 다음: [에이전트 오케스트레이션](agent-coordinator.md)
 - 상위: [목차](../README.md)

--- a/docs/ko/level-2-systems/query-engine.md
+++ b/docs/ko/level-2-systems/query-engine.md
@@ -15,7 +15,7 @@ graph TD
     QE["QueryEngine\n(src/QueryEngine.ts)"]
     ASK["ask()\n편의 래퍼"]
     QUERY["query()\n(src/query.ts)"]
-    CLAUDE["services/api/claude.ts\nAnthropics API 클라이언트"]
+    CLAUDE["services/api/claude.ts\nAnthropic API 클라이언트"]
     TOOLS["Tool 시스템\n(src/Tool.ts)"]
     COST["cost-tracker.ts\n비용·토큰 집계"]
     COMPACT["services/compact/\n컨텍스트 압축"]


### PR DESCRIPTION
## Summary

Claude Code CLI 소스코드(~1,900 파일, 512K+ 라인 TypeScript)를 체계적으로 분석한 **한국어 기술 문서** 19개를 추가합니다.

- **Level 1 (입문)**: 전체 아키텍처 조감도, 요청 생명주기 추적, 15개 핵심 개념 정리
- **Level 2 (시스템 분석)**: QueryEngine, Tool 시스템, 커맨드 시스템, 권한 시스템, 멀티에이전트 오케스트레이션, React/Ink UI
- **Level 3 (심화)**: MCP/LSP 프로토콜 연동, IDE 브릿지, 플러그인/스킬 시스템, 컨텍스트 압축, OAuth 인증, 텔레메트리
- **Appendix**: 한영 용어 대조표(50+항목), 파일 경로 인덱스, 설계 패턴 모음(8개)

### 주요 특징

- 🇰🇷 **한국인 개발자 대상**: 학술적/기술 문서 톤, 한영 용어 병기
- 📊 **레이어드 구조**: 입문 → 중급 → 심화 순서로 자신의 레벨에 맞는 진입점 선택 가능
- 🔍 **소스코드 기반**: 모든 문서가 실제 코드를 직접 분석하여 작성 (파일 경로, 라인 번호, 코드 스니펫 포함)
- 📈 **Mermaid 다이어그램**: 아키텍처, 시퀀스, 플로우차트 등 GitHub 네이티브 렌더링 지원

### 문서 구조

```
docs/ko/
├── README.md                     — 인덱스 & 읽기 가이드
├── level-1-overview/             — 입문 (3개)
│   ├── architecture.md           — 전체 아키텍처 조감도
│   ├── request-lifecycle.md      — 요청 생명주기 (backbone)
│   └── key-concepts.md           — 15개 핵심 개념
├── level-2-systems/              — 시스템 분석 (6개)
│   ├── query-engine.md           — QueryEngine 분석
│   ├── tool-system.md            — Tool 시스템 분석
│   ├── command-system.md         — 커맨드 시스템 분석
│   ├── permission-system.md      — 권한 시스템 분석
│   ├── agent-coordinator.md      — 멀티에이전트 오케스트레이션
│   └── ui-ink-components.md      — React/Ink UI 분석
├── level-3-internals/            — 심화 분석 (6개)
│   ├── mcp-lsp-integration.md    — MCP/LSP 프로토콜 연동
│   ├── bridge-ide.md             — IDE 브릿지
│   ├── plugin-skill-system.md    — 플러그인 & 스킬 시스템
│   ├── context-compression.md    — 컨텍스트 압축
│   ├── oauth-auth.md             — 인증 흐름
│   └── telemetry.md              — 텔레메트리
└── appendix/                     — 부록 (3개)
    ├── glossary.md               — 한영 용어 대조표 (50+항목)
    ├── file-map.md               — 파일 경로 인덱스
    └── design-patterns.md        — 설계 패턴 모음 (8개)
```

### 총 규모
- **19개 문서**, **6,926줄**
- 실제 소스코드를 직접 읽고 분석하여 작성

## Test plan

- [x] 모든 19개 마크다운 파일 생성 확인
- [x] 한국어 문서 톤 및 용어 일관성 검증
- [x] 내부 링크 구조 확인 (README ↔ 각 문서)
- [ ] GitHub에서 Mermaid 다이어그램 렌더링 확인
- [ ] 오탈자 및 기술적 정확성 최종 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)