### PR TITLE
docs: add architecture and security audit reports

### DIFF
--- a/audit-report-en.md
+++ b/audit-report-en.md
@@ -1,0 +1,250 @@
+# Project Risk Review Report
+
+## Review Approach and Priority Scope
+
+### Review approach
+- First, understand the overall project structure, identify entrypoints, core service layers, and remote/plugin/tool execution paths, and determine system boundaries and privileged paths.
+- Then drill into high-risk areas: authentication and authorization, configuration and environment variables, remote sessions, MCP/plugin extensibility, file handling, external APIs, logging and telemetry, and error handling.
+- Finally assess engineering governance: test coverage, dependency and release materials, module coupling, observability, resilience controls, and future evolution risk.
+
+### Key files and modules inspected
+- Entry and orchestration: `src/main.tsx`
+- Auth and session: `src/utils/auth.ts`, `src/utils/sessionIngressAuth.ts`, `src/services/oauth/*`
+- Permission control: `src/utils/permissions/permissionSetup.ts`, `src/remote/remotePermissionBridge.ts`
+- API and external calls: `src/services/api/client.ts`, `src/services/api/claude.ts`, `src/services/api/filesApi.ts`, `src/services/api/sessionIngress.ts`
+- Remote connectivity: `src/remote/RemoteSessionManager.ts`, `src/remote/SessionsWebSocket.ts`, `src/server/createDirectConnectSession.ts`
+- MCP / plugins: `src/services/mcp/client.ts`, `src/services/mcp/auth.ts`, `src/services/mcp/config.ts`, `src/services/mcp/channelPermissions.ts`, `src/services/mcp/headersHelper.ts`, `src/utils/plugins/pluginLoader.ts`
+- Config and environment: `src/utils/config.ts`, `src/setup.ts`
+- Logging and telemetry: `src/services/internalLogging.ts`, `src/utils/log.ts`, `src/services/analytics/*`
+- History and persistence: `src/history.ts`
+- Test and engineering artifacts: no standard test directories, dependency manifest files, Dockerfile, or CI workflows were present in the delivered snapshot
+
+---
+
+## 1. Executive Summary
+
+- This review was performed against the delivered `src/` snapshot only. The repository root contains only `src/` and `src.zip`; `package.json`, lockfiles, Dockerfiles, and CI workflow files were not present. As a result, some dependency, deployment, and release conclusions can only be marked as potential risks.
+- The most material issues are not classic SQL injection findings, but privileged capability boundary issues: remote sessions can explicitly skip permission prompts, MCP `headersHelper` can execute shell commands from repository-controlled config in non-interactive mode, and channel-based permission relay explicitly accepts the possibility of forged approvals from compromised services.
+- From a stability and maintainability perspective, the project shows strong signs of core-module concentration: `src/main.tsx` is 4684 lines, `src/services/api/claude.ts` is 3420 lines, `src/services/mcp/client.ts` is 3349 lines, `src/utils/auth.ts` is 2003 lines, `src/utils/config.ts` is 1818 lines, and `src/utils/plugins/pluginLoader.ts` is 3303 lines. This increases architecture complexity and regression risk.
+- From a quality perspective, no conventional test files were visible in the delivered snapshot. There are also issues with swallowed error semantics, telemetry collecting permission context, and file APIs with elevated memory ceilings, all of which reduce confidence for production readiness.
+- Positive note: some governance controls do exist. For example, `zod` validation is used in `src/services/api/bootstrap.ts:19` and `src/server/createDirectConnectSession.ts:71`, and team-memory sync includes secret scanning in `src/services/teamMemorySync/secretScanner.ts`. However, these controls do not yet cover the most critical privileged boundaries.
+
+## 2. Overall Risk Rating
+
+- Rating: High
+- Basis:
+  - High-risk capabilities can bypass or materially weaken permission boundaries.
+  - Repository-configured shell execution is possible in non-interactive scenarios.
+  - A forged-approval trust model is explicitly accepted for channel-based permissions.
+  - Security-critical logic is concentrated in very large files with no visible tests.
+  - The delivered snapshot lacks dependency and deployment metadata required for a full supply-chain audit.
+
+## 3. Key High-Risk Findings
+
+- Direct-connect remote sessions support `dangerously_skip_permissions`, and the client passes this directly to the server, exposing a privileged bypass capability. Location: `src/server/createDirectConnectSession.ts:52`
+- MCP `headersHelper` skips workspace trust validation in non-interactive mode and executes configured content with `shell: true`, creating a repository-configured command execution risk. Location: `src/services/mcp/headersHelper.ts:41`, `src/services/mcp/headersHelper.ts:61`
+- The channel permission relay model explicitly accepts that a compromised allowlisted channel server can fabricate `yes <id>` approvals. This is a trust-boundary design issue, not merely an implementation bug. Location: `src/services/mcp/channelPermissions.ts:15`
+
+## 4. Complete Risk Details
+
+### Finding 1: Direct-connect sessions can bypass all permission prompts
+- Severity: High
+- Category: Authentication and Authorization
+- Location: `src/server/createDirectConnectSession.ts:26`
+- Evidence:
+  - The request body directly includes `dangerously_skip_permissions: true`. `src/server/createDirectConnectSession.ts:52`
+  - There is no visible additional server capability confirmation or secondary constraint on the client side; behavior is controlled by input parameters alone. `src/server/createDirectConnectSession.ts:30`
+- Impact:
+  - If misused, scripted, or exposed through weak control-plane protections, a remote session can lose its last human approval gate.
+  - For production readiness, this is a privileged capability exposure issue, not a minor implementation detail.
+- Remediation:
+  - Move this to strict server-side enforcement with an explicit allowlist and limit it to controlled environments and principals.
+  - Add audit logging, stronger confirmation, or short-lived capability tokens.
+  - Separate debugging/experimental capabilities from production capabilities at the protocol level.
+
+### Finding 2: `headersHelper` can execute shell from repository-controlled configuration in non-interactive mode
+- Severity: High
+- Category: Command Execution / Supply Chain / Workspace Trust
+- Location: `src/services/mcp/headersHelper.ts:32`
+- Evidence:
+  - The code explicitly states that trust checks are skipped in non-interactive mode. `src/services/mcp/headersHelper.ts:41`
+  - Execution uses `shell: true`. `src/services/mcp/headersHelper.ts:61`
+  - The input source is config-driven via MCP `headersHelper`. `src/services/mcp/headersHelper.ts:36`
+- Impact:
+  - In CI/CD, automation, batch jobs, or service accounts, repository-local `.mcp.json` or project config can trigger command execution.
+  - This is a classic engineering-chain risk: the attack surface is not external user input, but repository or supply-chain content.
+- Remediation:
+  - Disable project/local-scope `headersHelper` by default in non-interactive mode.
+  - Remove `shell: true` and require explicit executable plus argv.
+  - Apply allowlisting, signature verification, or fixed-directory validation for helper paths; require explicit `--allow-headers-helper` in CI.
+
+### Finding 3: Channel permission relay accepts forged approvals from compromised services
+- Severity: High
+- Category: Permission Boundary / Trust Boundary
+- Location: `src/services/mcp/channelPermissions.ts:15`
+- Evidence:
+  - The comments explicitly state that a compromised channel server “CAN fabricate yes <id>” and classify it as an accepted risk. `src/services/mcp/channelPermissions.ts:17`
+  - Client-side resolution only matches `requestId`; it does not validate end-user proof. `src/services/mcp/channelPermissions.ts:228`
+- Impact:
+  - Any compromised or abused allowlisted channel service can bypass genuine user approval and participate in privileged action chains.
+  - This is a systemic trust-model weakness rather than a localized bug.
+- Remediation:
+  - Upgrade approval from server assertion to user-signed confirmation or a one-time challenge-response.
+  - Downgrade channel approval to auxiliary signaling; final approval should still occur in a trusted local or managed UI.
+  - At minimum, disable channel approval for high-risk tool categories.
+
+### Finding 4: Internal telemetry records full permission context and container identity
+- Severity: Medium
+- Category: Logging and Privacy
+- Location: `src/services/internalLogging.ts:71`
+- Evidence:
+  - The event includes a fully serialized `toolPermissionContext`. `src/services/internalLogging.ts:84`
+  - It also records namespace and container ID. `src/services/internalLogging.ts:82`, `src/services/internalLogging.ts:87`
+- Impact:
+  - Permission rules, workload location, and container identifiers together can create a highly sensitive internal operational profile.
+  - If telemetry fields expand without governance, strategy details or environment information may also leak.
+- Remediation:
+  - Minimize collection to mode and rule counts instead of full JSON.
+  - Hash or classify `containerId` and `namespace` before export.
+  - Establish a telemetry field allowlist review process.
+
+### Finding 5: Session log fetching swallows 401 semantics and degrades auth failures to `null`
+- Severity: Medium
+- Category: Error Handling / Reliability
+- Location: `src/services/api/sessionIngress.ts:420`
+- Evidence:
+  - On 401, the code first throws “Please run /login to sign in again.” `src/services/api/sessionIngress.ts:462`
+  - But the outer `catch` collapses the outcome to `null`, so callers cannot distinguish auth expiry from ordinary retrieval failure. `src/services/api/sessionIngress.ts:477`
+  - In the same file, `getTeleportEvents()` throws directly on 401, creating inconsistent semantics. `src/services/api/sessionIngress.ts:355`
+- Impact:
+  - Callers may misinterpret the issue as “no logs” or “temporary failure,” reducing diagnostic clarity and misleading users.
+  - Over time, this can produce hidden consistency issues and support confusion.
+- Remediation:
+  - Introduce structured error types such as `auth_expired`, `not_found`, and `network_error`.
+  - Stop collapsing all outer-layer failures to `null`.
+  - Standardize the error contract between session-ingress and teleport flows.
+
+### Finding 6: Files API uses whole-buffer memory handling for large files
+- Severity: Medium
+- Category: Performance and Stability
+- Location: `src/services/api/filesApi.ts:132`
+- Evidence:
+  - Downloads use `responseType: 'arraybuffer'` and then convert the full payload to a `Buffer`. `src/services/api/filesApi.ts:149`, `src/services/api/filesApi.ts:158`
+  - Default download concurrency is 5. `src/services/api/filesApi.ts:269`, `src/services/api/filesApi.ts:320`
+  - Uploads read the full file into memory before size validation; the single-file ceiling is 500MB. `src/services/api/filesApi.ts:396`, `src/services/api/filesApi.ts:413`
+- Impact:
+  - Multi-file operations can cause high memory spikes, especially in remote or low-memory environments, and may trigger OOM or severe process degradation.
+  - This is especially risky for large files and containerized runtimes.
+- Remediation:
+  - Change downloads to streaming writes and uploads to streaming multipart.
+  - Add Content-Length prechecks and hard size caps on download paths as well.
+  - Dynamically reduce concurrency based on available memory instead of using a fixed value.
+
+### Finding 7: Weak validation on critical message inputs
+- Severity: Medium (Potential Risk)
+- Category: Input and Output Validation
+- Location: `src/remote/SessionsWebSocket.ts:46`, `src/services/api/filesApi.ts:722`
+- Evidence:
+  - WebSocket inbound messages are accepted as long as they are objects with a string `type` field. `src/remote/SessionsWebSocket.ts:46`
+  - The code explicitly avoids an allowlist. `src/remote/SessionsWebSocket.ts:50`
+  - File spec parsing only splits on the first `:` and whitespace, without stronger schema enforcement. `src/services/api/filesApi.ts:726`
+- Impact:
+  - Under backend drift, proxy corruption, or polluted upstream input, the client is more likely to mis-handle messages or behave unpredictably.
+  - This is currently more of a robustness issue, but it can become a security issue when coupled with privileged flows.
+- Remediation:
+  - Introduce layered schema validation for control and session messages.
+  - Replace string-concatenated file specs with explicit JSON or structured parameters.
+  - Isolate and record unknown message types rather than allowing them into the main flow by default.
+
+### Finding 8: No visible automated tests in the delivered snapshot
+- Severity: Medium (Potential Risk)
+- Category: Test Governance
+- Location: whole `src/`
+- Evidence:
+  - No `src/**/*.{test,spec}.{ts,tsx,js,jsx}` files were found.
+  - No `src/**/__tests__/**/*` directories were found.
+  - The project contains many security-critical modules and complex permission state machines.
+- Impact:
+  - Production review cannot confirm regression coverage for permission modes, remote sessions, MCP, token refresh, or error recovery.
+  - Security fixes are more likely to introduce new bypasses or regressions.
+- Remediation:
+  - Add at least unit and integration coverage for auth, permissions, remote sessions, MCP, files API, and error contracts.
+  - Include dangerous modes, non-interactive mode, and 401/409/404 paths in mandatory regression suites.
+  - If tests exist outside the delivered snapshot, provide the full repository before relying on this review for production sign-off.
+
+### Finding 9: Configuration and environment governance is overly complex
+- Severity: Medium
+- Category: Architecture and Maintainability
+- Location: `src/utils/config.ts:183`, `src/utils/auth.ts:120`, `src/main.tsx`
+- Evidence:
+  - `src/utils/config.ts` retains many deprecated or legacy fields such as `apiKeyHelper`, `env`, `cachedChangelog`, and legacy MCP fields. `src/utils/config.ts:185`, `src/utils/config.ts:237`
+  - There are over 1514 `process.env` references across the codebase.
+  - Core files are very large, including `src/main.tsx` at 4684 lines and `src/services/mcp/client.ts` at 3349 lines.
+- Impact:
+  - It is difficult to maintain clear dev/test/prod behavior boundaries, and the cognitive load for changes is high.
+  - Future enhancements are likely to create configuration conflicts and broad regression surfaces.
+- Remediation:
+  - Introduce a unified config schema and layered environment model, and reduce direct `process.env` reads.
+  - Split oversized files by concern: auth, transport, policy, persistence, telemetry.
+  - Create a deprecation retirement plan and freeze new legacy-style config entry points.
+
+### Finding 10: Missing dependency and deployment artifacts block full supply-chain review
+- Severity: Medium (Potential Risk)
+- Category: Dependency Governance / Release Governance
+- Location: repository root
+- Evidence:
+  - The root contains only `src/` and `src.zip`.
+  - No `package.json`, lockfile, Dockerfile, or workflow files were present.
+- Impact:
+  - Dependency versions, licenses, known vulnerabilities, build commands, release paths, environment isolation, and image baselines cannot be verified.
+  - For production review, this means the supply-chain risk posture remains incomplete.
+- Remediation:
+  - Provide the full repository, dependency manifests, lockfiles, CI/CD configuration, and deployment IaC.
+  - Add SCA, license scanning, SBOM generation, and reproducible build validation.
+  - Include deployment configuration and runtime configuration in the formal review baseline.
+
+## 5. Systemic Governance Recommendations
+
+- Tier privileged capabilities: classify `bypassPermissions`, channel approvals, dynamic header helpers, and remote control as P0 capabilities requiring security design review.
+- Consolidate configuration entry points: manage env, settings, project config, and managed config through a single schema and stop expanding legacy fields.
+- Harden non-interactive mode: disable repository-configured execution by default unless explicitly allowlisted.
+- Normalize error contracts: do not mix `null` and `false` to represent auth failures, business failures, and network failures.
+- Build a regression gate: define mandatory test coverage and smoke checks for auth, permissions, remote flows, MCP, files, and telemetry.
+- Complete release artifacts: dependency manifests, lockfiles, CI, deployment IaC, and runbooks should all be part of formal production review.
+
+## 6. Phased Remediation Roadmap
+
+### Phase 1 (1-2 weeks)
+- Disable or strictly constrain non-interactive `headersHelper`
+- Add server-side enforcement and audit controls for `dangerously_skip_permissions`
+- Fix swallowed 401 semantics in session log fetching
+- Lower default Files API concurrency and add download size protections
+
+### Phase 2 (2-4 weeks)
+- Add tests for remote sessions, permission modes, MCP auth, and file transfer flows
+- Add schema validation for WebSocket and control messages
+- Minimize and redact internal telemetry fields
+
+### Phase 3 (1-2 releases)
+- Split `main.tsx`, `mcp/client.ts`, `auth.ts`, and `config.ts`
+- Retire deprecated config fields and establish a unified config layer
+- Add dependency governance, SBOM, SCA, and release/deployment audit coverage
+
+### Phase 4 (ongoing)
+- Establish threat modeling, change review, and regression gates for privileged capabilities
+- Create pre-release security and stability checklists
+- Add alerting, error budgets, and operational postmortem loops
+
+## 7. Management Summary
+
+- The central management concern is not whether the code “works,” but whether privileged capability boundaries are adequately controlled. At present, they are not fully controlled.
+- If a production launch is imminent, non-interactive `headersHelper`, remote permission bypass, and the channel forged-approval trust model should be treated as launch blockers.
+- From a delivery-governance perspective, the current snapshot is missing dependency and deployment materials, so supply-chain and release risks have not been fully reviewed.
+- Over the medium term, the project shows typical complex-system warning signs: oversized core modules, diffuse configuration, coexistence of legacy and new patterns, and no visible tests. If left untreated, maintenance cost and change-related incident probability will continue to rise.
+- The recommended management sequence is: reduce privileged exposure first, add test coverage second, and then refactor core architecture, rather than continuing to layer new functionality on top.
+
+## Additional Notes
+
+- No confirmed production secrets, tokens, or passwords were found hardcoded in the current `src/` snapshot; however, because the repository is incomplete, this should be interpreted as “not found in reviewed scope,” not “proven absent.”
+- No direct SQL or ORM query code was identified in the reviewed scope, so database injection risk was not a primary finding in this snapshot.
+- Monitoring and telemetry capabilities do exist, for example in `src/services/analytics/datadog.ts`; however, no alert rules, dashboard IaC, or SLO/SLA materials were present, so operational observability cannot be considered fully governed.

--- a/audit-report-zh.md
+++ b/audit-report-zh.md
@@ -1,0 +1,250 @@
+# 项目风险审查报告
+
+## 审查思路与重点检查范围
+
+### 审查思路
+- 先整体理解项目结构，识别入口、核心服务层、远程/插件/工具执行链路，判断系统边界与高权限路径。
+- 再逐层下钻高风险面：鉴权与权限、配置与环境变量、远程会话、MCP/插件扩展、文件读写、外部 API、日志与遥测、异常处理。
+- 最后评估工程治理：测试覆盖、依赖与发布材料、模块耦合度、可观测性、容错与限流，以及未来演进阻力。
+
+### 重点检查的文件与模块
+- 入口与全局编排：`src/main.tsx`
+- 鉴权与会话：`src/utils/auth.ts`、`src/utils/sessionIngressAuth.ts`、`src/services/oauth/*`
+- 权限控制：`src/utils/permissions/permissionSetup.ts`、`src/remote/remotePermissionBridge.ts`
+- API 与外部调用：`src/services/api/client.ts`、`src/services/api/claude.ts`、`src/services/api/filesApi.ts`、`src/services/api/sessionIngress.ts`
+- 远程连接：`src/remote/RemoteSessionManager.ts`、`src/remote/SessionsWebSocket.ts`、`src/server/createDirectConnectSession.ts`
+- MCP / 插件：`src/services/mcp/client.ts`、`src/services/mcp/auth.ts`、`src/services/mcp/config.ts`、`src/services/mcp/channelPermissions.ts`、`src/services/mcp/headersHelper.ts`、`src/utils/plugins/pluginLoader.ts`
+- 配置与环境：`src/utils/config.ts`、`src/setup.ts`
+- 日志与遥测：`src/services/internalLogging.ts`、`src/utils/log.ts`、`src/services/analytics/*`
+- 历史与数据落盘：`src/history.ts`
+- 测试与工程材料：交付目录中未发现常规测试目录、依赖清单文件、Dockerfile、CI workflow 等工程材料
+
+---
+
+## 1. 执行摘要
+
+- 本次审查基于交付目录中的 `src/` 代码快照完成；仓库根目录仅见 `src/` 与 `src.zip`，未发现 `package.json`、lockfile、Dockerfile、CI workflow 等工程材料，因此依赖、部署、发布链路的结论中有一部分只能标记为“潜在风险”。
+- 从安全与治理角度看，项目最突出的问题不在传统 SQL 注入，而在高权限能力边界：远程会话可显式跳过权限确认、MCP `headersHelper` 在非交互场景可执行仓库配置中的 shell、渠道型权限转发明确接受“被攻陷服务可伪造批准”。
+- 从稳定性与可维护性角度看，代码存在明显的“大文件核心模块”现象：`src/main.tsx` 4684 行、`src/services/api/claude.ts` 3420 行、`src/services/mcp/client.ts` 3349 行、`src/utils/auth.ts` 2003 行、`src/utils/config.ts` 1818 行、`src/utils/plugins/pluginLoader.ts` 3303 行，架构复杂度和变更风险偏高。
+- 从质量保障角度看，本次扫描未在交付快照中发现常规测试文件；同时存在错误语义被吞掉、日志/遥测采集权限上下文、文件 API 内存占用上界偏高等问题，已影响上线评审通过把握度。
+- 正向结论：在部分路径中已看到一定治理意识，例如 `zod` 校验已用于 `src/services/api/bootstrap.ts:19`、`src/server/createDirectConnectSession.ts:71`；团队记忆同步具备 secrets 扫描能力 `src/services/teamMemorySync/secretScanner.ts`。但这些措施尚未覆盖最关键的高权限边界。
+
+## 2. 项目总体风险评级
+
+- 评级：高
+- 依据：
+  - 存在可绕过或弱化权限边界的高风险能力。
+  - 存在非交互场景执行配置型 shell 的风险。
+  - 存在被明确“接受”的渠道自批准风险。
+  - 安全关键模块集中在超大文件中，缺少可见测试资产。
+  - 交付快照缺失依赖与部署元数据，无法完成完整供应链审计。
+
+## 3. 关键高风险问题
+
+- 远程直连会话支持 `dangerously_skip_permissions`，客户端直接透传到服务端，属于高权限绕过能力暴露。位置：`src/server/createDirectConnectSession.ts:52`
+- MCP `headersHelper` 在非交互模式跳过工作区信任校验，并以 `shell: true` 执行配置内容，存在仓库配置触发命令执行风险。位置：`src/services/mcp/headersHelper.ts:41`、`src/services/mcp/headersHelper.ts:61`
+- 渠道权限转发机制文档化接受“allowlisted channel server 被攻陷后可伪造 yes <id> 批准”的风险，属于明确的权限信任边界缺陷。位置：`src/services/mcp/channelPermissions.ts:15`
+
+## 4. 完整风险明细
+
+### 问题 1：远程直连会话可跳过全部权限确认
+- 等级：高
+- 类别：鉴权与权限控制
+- 位置：`src/server/createDirectConnectSession.ts:26`
+- 证据：
+  - 请求体直接拼入 `dangerously_skip_permissions: true`。`src/server/createDirectConnectSession.ts:52`
+  - 客户端无额外服务端能力确认、无二次约束，仅靠调用参数控制。`src/server/createDirectConnectSession.ts:30`
+- 影响：
+  - 一旦被误用、被脚本化调用或服务端控制面暴露不当，远程会话将失去最后一道人工确认。
+  - 对上线环境而言，这是“高危能力默认可被客户端发起”的设计风险，而非普通实现细节。
+- 修复建议：
+  - 将该能力改为服务端强校验加显式 allowlist，仅对受控环境、受控主体开放。
+  - 增加审计日志、双因子确认或短时一次性 capability token。
+  - 在协议层区分“调试/实验能力”与“生产能力”，避免同接口透传。
+
+### 问题 2：非交互模式下 `headersHelper` 可执行仓库配置中的 shell
+- 等级：高
+- 类别：命令执行 / 供应链 / 工作区信任
+- 位置：`src/services/mcp/headersHelper.ts:32`
+- 证据：
+  - 注释明确写明“非交互模式跳过 trust check”。`src/services/mcp/headersHelper.ts:41`
+  - 执行使用 `shell: true`。`src/services/mcp/headersHelper.ts:61`
+  - 输入来源是 MCP 配置中的 `headersHelper`，属于配置驱动执行。`src/services/mcp/headersHelper.ts:36`
+- 影响：
+  - 在 CI/CD、自动化、批处理、机器人账号等非交互场景，仓库内 `.mcp.json` 或项目配置可触发命令执行。
+  - 这是典型的工程链路风险：不是“外部攻击者输入”，而是“供应链/仓库内容”成为执行入口。
+- 修复建议：
+  - 非交互模式默认禁用 project/local scope 的 `headersHelper`。
+  - 去掉 `shell: true`，改为显式可执行文件加参数数组。
+  - 对 helper 路径做 allowlist、签名校验或固定目录校验；在 CI 中要求显式 `--allow-headers-helper`。
+
+### 问题 3：渠道型权限中继接受“被攻陷服务可伪造批准”
+- 等级：高
+- 类别：权限边界 / 信任边界
+- 位置：`src/services/mcp/channelPermissions.ts:15`
+- 证据：
+  - 注释明确说明：被攻陷的 channel server “CAN fabricate yes <id>”，且被定义为 “Accepted risk”。`src/services/mcp/channelPermissions.ts:17`
+  - 客户端 `resolve()` 只按 `requestId` 匹配，不校验用户侧证明。`src/services/mcp/channelPermissions.ts:228`
+- 影响：
+  - 只要 allowlisted 渠道服务被劫持或滥用，就可绕过真实用户确认，形成高权限操作链。
+  - 该问题不是“实现 bug”，而是体系化信任模型缺陷。
+- 修复建议：
+  - 将批准从“服务端声明”升级为“用户签名确认”或一次性 challenge-response。
+  - 把渠道批准降级为“辅助确认”，最终批准仍需本地或受信 UI 完成。
+  - 至少对高危工具类别禁用渠道批准。
+
+### 问题 4：内部遥测记录完整权限上下文与容器标识，存在敏感信息外泄面
+- 等级：中
+- 类别：日志与隐私
+- 位置：`src/services/internalLogging.ts:71`
+- 证据：
+  - 上报事件包含 `toolPermissionContext` 全量序列化。`src/services/internalLogging.ts:84`
+  - 同时采集 namespace 与 containerId。`src/services/internalLogging.ts:82`、`src/services/internalLogging.ts:87`
+- 影响：
+  - 权限规则、工作负载位置、容器标识组合后，可形成高敏内部运维画像。
+  - 若后续事件字段扩展不慎，还可能携带策略细节或环境信息，增加横向分析风险。
+- 修复建议：
+  - 对权限上下文做最小化采集，只保留模式与规则计数，不传完整 JSON。
+  - 对 containerId / namespace 做哈希或分级脱敏。
+  - 建立“遥测字段白名单评审”机制。
+
+### 问题 5：会话日志获取对 401 语义处理不一致，认证错误被吞为 `null`
+- 等级：中
+- 类别：异常处理 / 稳定性
+- 位置：`src/services/api/sessionIngress.ts:420`
+- 证据：
+  - 401 时先抛出“请重新登录”。`src/services/api/sessionIngress.ts:462`
+  - 但外层 `catch` 统一返回 `null`，导致调用方无法区分认证失效与普通拉取失败。`src/services/api/sessionIngress.ts:477`
+  - 同文件 `getTeleportEvents()` 对 401 则直接抛错，处理语义不一致。`src/services/api/sessionIngress.ts:355`
+- 影响：
+  - 调用方可能误判为“无日志”或“暂时失败”，影响故障排查、会话恢复与用户提示准确性。
+  - 长期会导致隐性数据一致性问题和运维误导。
+- 修复建议：
+  - 引入结构化错误类型，明确区分 `auth_expired`、`not_found`、`network_error`。
+  - 不要在最外层把所有异常折叠成 `null`。
+  - 统一 session ingress 与 teleport 的错误契约。
+
+### 问题 6：Files API 下载/上传采用整块内存缓冲，存在资源峰值风险
+- 等级：中
+- 类别：性能与稳定性
+- 位置：`src/services/api/filesApi.ts:132`
+- 证据：
+  - 下载使用 `responseType: 'arraybuffer'`，完成后整体转成 `Buffer`。`src/services/api/filesApi.ts:149`、`src/services/api/filesApi.ts:158`
+  - 下载并发默认 5。`src/services/api/filesApi.ts:269`、`src/services/api/filesApi.ts:320`
+  - 上传先整文件 `readFile` 再做大小判断；单文件上限 500MB。`src/services/api/filesApi.ts:396`、`src/services/api/filesApi.ts:413`
+- 影响：
+  - 多文件并发时容易造成高内存峰值，影响 CLI 稳定性，极端情况下触发 OOM 或系统抖动。
+  - 对大文件、远程环境、低内存容器尤其危险。
+- 修复建议：
+  - 下载改为流式写盘，上传改为流式 multipart。
+  - 在下载侧也做 Content-Length 预检和硬限制。
+  - 根据可用内存动态收敛并发，而不是固定 5。
+
+### 问题 7：关键消息输入校验偏弱，存在潜在协议鲁棒性风险
+- 等级：中
+- 类别：输入输出校验
+- 位置：`src/remote/SessionsWebSocket.ts:46`、`src/services/api/filesApi.ts:722`
+- 证据：
+  - WebSocket 入站消息仅判断“对象且含 string 类型的 `type` 字段”。`src/remote/SessionsWebSocket.ts:46`
+  - 注释明确选择“不做 allowlist”。`src/remote/SessionsWebSocket.ts:50`
+  - 文件规格解析仅按首个 `:` 和空格拆分，缺少更强 schema 校验。`src/services/api/filesApi.ts:726`
+- 影响：
+  - 在后端版本漂移、代理异常、被污染的上游输入下，客户端更容易出现误处理或不可预测行为。
+  - 当前更偏可用性和兼容性风险，但一旦与高权限动作耦合，安全风险会放大。
+- 修复建议：
+  - 对 control message / session message 建立 schema 分层校验。
+  - 对文件规格使用显式 JSON 或结构化参数，而不是字符串拼接协议。
+  - 对未知消息类型记录并隔离，不直接进入主流程。
+
+### 问题 8：测试资产在交付快照中不可见，安全关键路径缺少可验证保障
+- 等级：中
+- 类别：测试治理
+- 位置：`src/` 全局
+- 证据：
+  - 未发现 `src/**/*.{test,spec}.{ts,tsx,js,jsx}`。
+  - 未发现 `src/**/__tests__/**/*`。
+  - 但项目包含大量安全关键模块与复杂权限状态机。
+- 影响：
+  - 上线评审无法确认权限模式、远程会话、MCP、认证刷新、错误恢复等关键行为是否被回归覆盖。
+  - 安全修复很容易引入新绕过或新回归。
+- 修复建议：
+  - 至少补齐 auth、permission、remote session、MCP、files API、error contract 的单测/集成测试。
+  - 将“危险模式”“非交互模式”“401/409/404 路径”纳入强制回归集。
+  - 若测试位于未提供目录，需补充完整仓库再做正式上线审查。
+
+### 问题 9：配置与环境治理复杂度过高，旧新模型并存
+- 等级：中
+- 类别：架构与可维护性
+- 位置：`src/utils/config.ts:183`、`src/utils/auth.ts:120`、`src/main.tsx`
+- 证据：
+  - `src/utils/config.ts` 同时保留大量 deprecated/legacy 字段，如 `apiKeyHelper`、`env`、`cachedChangelog`、旧 MCP 字段。`src/utils/config.ts:185`、`src/utils/config.ts:237`
+  - 全代码树 `process.env` 命中 1514+ 处，环境变量散布广泛。
+  - 核心文件体量极大：`src/main.tsx` 4684 行、`src/services/mcp/client.ts` 3349 行等。
+- 影响：
+  - dev/test/prod 行为难以形成清晰边界，认知负担大，改动外溢风险高。
+  - 未来扩展时，极易出现模式冲突、回归和“修一处坏三处”。
+- 修复建议：
+  - 建立统一配置 schema 与环境分层，收敛 `process.env` 直接读取入口。
+  - 拆分超大文件，按 auth、transport、policy、persistence、telemetry 分层。
+  - 制定 deprecated 字段清退计划，冻结新增旧式配置入口。
+
+### 问题 10：依赖与部署审计材料缺失，供应链与可复现性无法确认
+- 等级：中
+- 类别：依赖治理 / 发布治理
+- 位置：仓库根目录
+- 证据：
+  - 根目录仅见 `src/` 与 `src.zip`。
+  - 未发现 `package.json`、lockfile、Dockerfile、workflow 文件。
+- 影响：
+  - 无法确认依赖版本、许可证、已知漏洞、构建命令、发布路径、环境隔离、镜像基线。
+  - 对上线评审来说，这意味着供应链风险未被充分审计。
+- 修复建议：
+  - 补充完整仓库、依赖清单、锁文件、CI/CD 配置、部署 IaC。
+  - 引入 SCA、license scan、SBOM 与可复现构建校验。
+  - 将部署配置与运行时配置纳入正式评审基线。
+
+## 5. 系统性治理建议
+
+- 建立高权限能力分级：将 `bypassPermissions`、渠道批准、动态 header helper、远程控制列为 P0 能力，统一走安全设计评审。
+- 收敛配置入口：以单一 schema 管理 env、settings、project config、managed config，禁止继续扩散 legacy 字段。
+- 强化非交互安全策略：默认禁用仓库配置驱动执行，必须显式白名单开启。
+- 统一错误契约：安全相关接口不要再用 `null/false` 混合表达认证失败、业务失败、网络失败。
+- 建立测试金线：为 auth、permission、remote、MCP、files、telemetry 定义强制用例和冒烟基线。
+- 完整化交付材料：依赖清单、锁文件、CI、部署 IaC、运行手册必须进入上线审查范围。
+
+## 6. 分阶段整改路线图
+
+### 阶段 1（1-2 周）
+- 禁用或严控非交互 `headersHelper`
+- 为 `dangerously_skip_permissions` 增加服务端强校验和审计
+- 修复 session log 401 被吞问题
+- 降低 files API 默认并发并增加下载大小保护
+
+### 阶段 2（2-4 周）
+- 为远程会话、权限模式、MCP 鉴权、文件传输补齐测试
+- 将 WebSocket/control message 改为 schema 校验
+- 对 internal telemetry 做字段最小化与脱敏
+
+### 阶段 3（1-2 个版本）
+- 拆分 `main.tsx`、`mcp/client.ts`、`auth.ts`、`config.ts`
+- 清退 deprecated 配置字段，建立统一 config layer
+- 补齐依赖治理、SBOM、SCA、发布与部署审计链路
+
+### 阶段 4（持续）
+- 对高权限能力建立 threat modeling、变更评审与回归门禁
+- 建立上线前安全检查表与稳定性检查表
+- 引入告警、错误预算和运行后复盘闭环
+
+## 7. 管理层摘要
+
+- 该项目当前最值得管理层关注的，不是“代码写得对不对”，而是“高权限能力边界是否可控”。目前答案是不完全可控。
+- 如果近期要上线，建议把 `headersHelper` 非交互执行、远程权限绕过、渠道自批准信任模型列为上线阻断项。
+- 从交付治理看，当前快照缺失依赖与部署材料，意味着供应链和发布风险没有被完整评审，不能视为“审查已完成”。
+- 从中长期看，项目具备产品能力和工程积累，但已出现典型复杂系统信号：超大核心文件、配置分散、旧新并存、测试不可见。若不治理，未来维护成本和变更事故概率会持续上升。
+- 建议管理层以“先收权、再补测、后拆分”的顺序推进整改，而不是继续叠加功能。
+
+## 补充说明
+
+- 未在当前 `src/` 快照中发现可确认的生产 secrets、token、password 硬编码；但由于仓库不完整，只能给出“未发现，不代表不存在”的审计结论。
+- 未发现直接 SQL/ORM 查询代码，数据库注入类风险在当前扫描范围内不突出。
+- 监控与 telemetry 能力是存在的，例如 `src/services/analytics/datadog.ts`；但未见告警规则、仪表盘 IaC、SLO/SLA 材料，因此运维可观测性仍不能算“已闭环”。


### PR DESCRIPTION
Add standalone Chinese and English review reports for project launch readiness. The reports assess security, architecture, maintainability, engineering governance, operational risk, and delivery quality, with evidence-based findings and a phased remediation roadmap.