### PR TITLE
fix: resolve EACCES error from incorrect bundled plugins directory

### DIFF
--- a/rust/crates/plugins/src/lib.rs
+++ b/rust/crates/plugins/src/lib.rs
@@ -1037,8 +1037,59 @@ impl PluginManager {
         Self { config }
     }
 
+    /// Returns the default bundled plugins root directory.
+    ///
+    /// Resolution order (first existing path wins):
+    /// 1. `<exe_dir>/../share/claw/plugins/bundled` — standard install layout
+    /// 2. `<exe_dir>/bundled` — simple relocated layout
+    /// 3. `CARGO_MANIFEST_DIR/bundled` — dev/source-tree fallback (only if it exists)
+    /// 4. `<exe_dir>/../share/claw/plugins/bundled` — canonical default even if missing
+    ///
+    /// This avoids baking in a compile-time source-tree path that may be
+    /// inaccessible at runtime (e.g. a root-owned repo directory).
     #[must_use]
     pub fn bundled_root() -> PathBuf {
+        // Candidate 1: standard FHS install layout — <prefix>/bin/claw -> <prefix>/share/claw/plugins/bundled
+        if let Ok(exe_path) = std::env::current_exe() {
+            if let Some(exe_dir) = exe_path.parent() {
+                let share_path = exe_dir
+                    .join("..")
+                    .join("share")
+                    .join("claw")
+                    .join("plugins")
+                    .join("bundled");
+                if share_path.exists() {
+                    return share_path;
+                }
+
+                // Candidate 2: simple adjacent layout — <exe_dir>/bundled
+                let adjacent = exe_dir.join("bundled");
+                if adjacent.exists() {
+                    return adjacent;
+                }
+            }
+        }
+
+        // Candidate 3: dev/source-tree fallback — only if the directory actually exists
+        let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("bundled");
+        if dev_path.exists() {
+            return dev_path;
+        }
+
+        // Default (nothing found): return the canonical install path even if missing,
+        // so callers get an empty plugin list rather than a permission error.
+        if let Ok(exe_path) = std::env::current_exe() {
+            if let Some(exe_dir) = exe_path.parent() {
+                return exe_dir
+                    .join("..")
+                    .join("share")
+                    .join("claw")
+                    .join("plugins")
+                    .join("bundled");
+            }
+        }
+
+        // Last resort fallback
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("bundled")
     }
 
@@ -1357,12 +1408,24 @@ impl PluginManager {
     }
 
     fn sync_bundled_plugins(&self) -> Result<(), PluginError> {
+        let explicit_root = self.config.bundled_root.is_some();
         let bundled_root = self
             .config
             .bundled_root
             .clone()
             .unwrap_or_else(Self::bundled_root);
-        let bundled_plugins = discover_plugin_dirs(&bundled_root)?;
+        let bundled_plugins = match discover_plugin_dirs(&bundled_root) {
+            Ok(plugins) => plugins,
+            // When the bundled root is the auto-detected default and the directory is
+            // inaccessible (e.g. a root-owned source tree), treat it as empty rather
+            // than fatally failing.  An explicit config override still surfaces errors.
+            Err(PluginError::Io(ref error))
+                if !explicit_root && error.kind() == std::io::ErrorKind::PermissionDenied =>
+            {
+                Vec::new()
+            }
+            Err(error) => return Err(error),
+        };
         let mut registry = self.load_registry()?;
         let mut changed = false;
         let install_root = self.install_root();
@@ -2976,17 +3039,139 @@ mod tests {
     fn default_bundled_root_loads_repo_bundles_as_installed_plugins() {
         let _guard = env_guard();
         let config_home = temp_dir("default-bundled-home");
-        let manager = PluginManager::new(PluginManagerConfig::new(&config_home));
+
+        // Use the repo bundled path explicitly so the test is reliable regardless
+        // of where the binary runs from.
+        let repo_bundled = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("bundled");
+        let mut config = PluginManagerConfig::new(&config_home);
+        config.bundled_root = Some(repo_bundled.clone());
+        let manager = PluginManager::new(config);
+
+        if repo_bundled.exists() {
+            let installed = manager
+                .list_installed_plugins()
+                .expect("bundled plugins should auto-install from repo path");
+            assert!(installed
+                .iter()
+                .any(|plugin| plugin.metadata.id == "example-bundled@bundled"));
+            assert!(installed
+                .iter()
+                .any(|plugin| plugin.metadata.id == "sample-hooks@bundled"));
+        }
+
+        let _ = fs::remove_dir_all(config_home);
+    }
+
+    #[test]
+    fn default_bundled_root_is_not_blindly_cargo_manifest_dir() {
+        // Verify that bundled_root() no longer unconditionally returns
+        // CARGO_MANIFEST_DIR/bundled.  The returned path must either exist
+        // (a valid runtime or dev location was found) OR differ from the
+        // compile-time source path (a runtime-relative default was chosen).
+        let resolved = PluginManager::bundled_root();
+        let compile_time_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("bundled");
+
+        // If the compile-time path does not exist (e.g. installed binary running
+        // outside the source tree), the resolved path must NOT be the CARGO_MANIFEST_DIR
+        // path, because that would re-introduce the original bug.
+        if !compile_time_path.exists() {
+            assert_ne!(
+                resolved, compile_time_path,
+                "bundled_root() must not fall back to CARGO_MANIFEST_DIR when that path \
+                 does not exist — this would regress the root-owned-dir permission bug"
+            );
+        }
+        // Either the path exists (dev scenario) or we got a runtime-relative path.
+        // Either way the function should not panic or return an obviously wrong value.
+        assert!(
+            !resolved.as_os_str().is_empty(),
+            "bundled_root() should return a non-empty path"
+        );
+    }
+
+    #[test]
+    fn override_bundled_root_is_used_exactly() {
+        let _guard = env_guard();
+        let config_home = temp_dir("override-bundled-home");
+        let bundled_root = temp_dir("override-bundled-root");
+        write_bundled_plugin(
+            &bundled_root.join("override-plugin"),
+            "override-plugin",
+            "1.0.0",
+            false,
+        );
+
+        let mut config = PluginManagerConfig::new(&config_home);
+        config.bundled_root = Some(bundled_root.clone());
+        let manager = PluginManager::new(config);
 
         let installed = manager
             .list_installed_plugins()
-            .expect("default bundled plugins should auto-install");
-        assert!(installed
-            .iter()
-            .any(|plugin| plugin.metadata.id == "example-bundled@bundled"));
-        assert!(installed
-            .iter()
-            .any(|plugin| plugin.metadata.id == "sample-hooks@bundled"));
+            .expect("override bundled_root should be used");
+        assert!(
+            installed
+                .iter()
+                .any(|plugin| plugin.metadata.id == "override-plugin@bundled"),
+            "only the override bundled root should be scanned, not CARGO_MANIFEST_DIR"
+        );
+
+        let _ = fs::remove_dir_all(config_home);
+        let _ = fs::remove_dir_all(bundled_root);
+    }
+
+    #[test]
+    fn explicit_nonexistent_bundled_root_does_not_fail() {
+        // When bundled_root is explicitly configured to a path that does not exist,
+        // plugin list should succeed with an empty bundled section rather than
+        // returning an error (discover_plugin_dirs treats NotFound as empty).
+        let _guard = env_guard();
+        let config_home = temp_dir("missing-bundled-home");
+
+        let nonexistent = temp_dir("nonexistent-bundled-XXXXXXXX");
+        assert!(
+            !nonexistent.exists(),
+            "test precondition: path must not exist"
+        );
+
+        let mut config = PluginManagerConfig::new(&config_home);
+        config.bundled_root = Some(nonexistent);
+        let manager = PluginManager::new(config);
+
+        // Should succeed with zero bundled plugins, not crash with ENOENT.
+        let result = manager.list_installed_plugins();
+        assert!(
+            result.is_ok(),
+            "nonexistent explicit bundled root should not fail: {result:?}"
+        );
+        let installed = result.unwrap();
+        assert!(
+            installed
+                .iter()
+                .all(|p| p.metadata.kind != PluginKind::Bundled),
+            "no bundled plugins should be installed when bundled root path does not exist"
+        );
+
+        let _ = fs::remove_dir_all(config_home);
+    }
+
+    #[test]
+    fn no_bundled_root_config_uses_auto_detection_without_panic() {
+        // When bundled_root is not set (None), auto-detection runs.  The resolved
+        // path should either exist (dev environment) or be a runtime-relative path
+        // that doesn't cause a panic or EACCES crash.
+        let _guard = env_guard();
+        let config_home = temp_dir("auto-detect-bundled-home");
+
+        // No bundled_root set — forces auto-detection in bundled_root().
+        let config = PluginManagerConfig::new(&config_home);
+        let manager = PluginManager::new(config);
+
+        // Should not panic or return a hard IO error.
+        let result = manager.list_installed_plugins();
+        assert!(
+            result.is_ok(),
+            "auto-detected bundled root resolution must not fail: {result:?}"
+        );
 
         let _ = fs::remove_dir_all(config_home);
     }


### PR DESCRIPTION
**Cam's Explanation:**
Hello, I found an issue with the resulting binary when following the quick start guide and doing:
```
# Inspect available commands
cd rust/
cargo run -p rusty-claude-cli -- --help

# Build the workspace (build a release binary instead) 
cargo build -r --workspace
```
when using the resulting binary: `rust/target/release/claw`, it would try to access `/root/claw/claw-code/rust/crates/plugins/bundled`, the program would error and fail due to permission denied and the program would then exit. This PR fixes that behavior. 

---
**Copilot's Explanation:**
`PluginManager::bundled_root()` used `env!("CARGO_MANIFEST_DIR")` to locate bundled plugins, baking in the source-tree path at compile time (e.g. `/root/claw/claw-code/rust/crates/plugins/bundled`). A binary built from a root-owned checkout fails with `EACCES` for non-root users on startup.

## Changes

- **`bundled_root()` resolution order** (first existing path wins):
  1. `<exe_dir>/../share/claw/plugins/bundled` — standard FHS install
  2. `<exe_dir>/bundled` — simple relocated layout
  3. `CARGO_MANIFEST_DIR/bundled` — dev/source-tree fallback, **only if it exists**
  4. `<exe_dir>/../share/claw/plugins/bundled` — canonical default when nothing found

- **`sync_bundled_plugins()` error handling** — `EACCES` on the *auto-detected* default bundled root is now treated as an empty plugin list rather than a fatal error. Explicit `plugins.bundledRoot` config overrides continue to surface errors normally.

- **Tests** (4 new/updated):
  - `default_bundled_root_is_not_blindly_cargo_manifest_dir` — asserts the compile-time path is not returned when it doesn't exist
  - `override_bundled_root_is_used_exactly` — explicit config override is honored
  - `explicit_nonexistent_bundled_root_does_not_fail` — missing explicit path yields empty bundled list, no error
  - `no_bundled_root_config_uses_auto_detection_without_panic` — `bundled_root = None` auto-detection path doesn't panic

```rust
// Before
pub fn bundled_root() -> PathBuf {
    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("bundled") // baked-in at compile time
}

// After: runtime resolution with dev fallback only when path exists
pub fn bundled_root() -> PathBuf {
    // 1. <exe_dir>/../share/claw/plugins/bundled
    // 2. <exe_dir>/bundled
    // 3. CARGO_MANIFEST_DIR/bundled  (only if exists — dev only)
    // 4. canonical share path as default
}
```

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

Create a fix in the `camAtGitHub/claw-code` fork (base `main`) for the upstream bug in `ultraworkers/claw-code` Rust workspace under `rust/`.

## Background / bug
When building `rust/target/release/claw` from a repo cloned under a root-owned directory (e.g. `/root/claw/claw-code`), the runtime attempts to open the bundled plugins directory at startup from a compile-time path:
- `/root/claw/claw-code/rust/crates/plugins/bundled`
This happens because `PluginManager::bundled_root()` uses `env!("CARGO_MANIFEST_DIR")` and returns `.../bundled`.
When the binary runs as a non-root user, this path may be unreadable, causing `EACCES` and early program exit.

The user validated that setting runtime config `plugins.bundledRoot` in project config (e.g. `/opt/defender-spyder-workspace/.claw.json`) works, but the default fallback remains broken.

## Required change
Modify the default bundled plugins root resolution so it is suitable for installed/relocated binaries and does not depend on `CARGO_MANIFEST_DIR` unless explicitly intended.

### Constraints
- Preserve existing behavior when `PluginManagerConfig.bundled_root` is explicitly provided (e.g. via runtime config `plugins.bundledRoot`).
- Prefer a runtime-located path, such as relative to `std::env::current_exe()` (e.g. `<exe_dir>/../share/claw/plugins/bundled` or `<exe_dir>/bundled`). Choose a reasonable convention.
- It’s acceptable to keep a dev fallback to `CARGO_MANIFEST_DIR/bundled`, but only if it exists and as a last resort.
- Ensure behavior is cross-platform where possible.

## Tests
Add/adjust unit tests in the plugins crate to cover:
- When `bundled_root` is not set, the default no longer blindly returns `CARGO_MANIFEST_DIR/bundled`.
- When the repo-bundled path exists (dev scenario), the manager can still load repo bundled plugins.
- When an override `bundled_root` is provided, that value is used.

Tests should be reliable in CI.

## Acceptance criteria
- Running a release-built `claw` binary from a root-owned repo checkout as a non-root user should no longer attempt to open `/root/.../rust/crates/plugins/bundled` by default.
- Existing config override continues to work.
- Tests pass.

## Relevant code
- `rust/crates/plugins/src/lib.rs`: `PluginManager::bundled_root()` currently uses `env!("CARGO_MANIFEST_DIR")`.
- `sync_bundled_plugins()` uses `config.bundled_root.unwrap_or_else(Self::bundled_root)`.

Please implement the fix and open a PR on the fork.

The following is the prior conversation context from the user's chat exploration (may be truncated):

User: i cloned this repo and from the rust directory i ran: `cargo build -r --workspace`  it worked.
For reference I cloned the repo to my local directory `/root/claw/claw-code` and the compiled binary during startup now has the fatal to non-root flaw that the binary is trying to access `/root/claw/claw-code/rust/crates/plugins/bundled` - it gets permission error and exits the program early into the startup.

My strace shows the issue:
```
openat(AT_FDCWD, "/opt/defender-spyder-workspace/.claw/settings.json", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/opt/defender-spyder-workspace/.claw/settings.local.json", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
getcwd("/opt/defender-spyder-workspace", 512) = 31
getcwd("/opt/defender-spyder-workspace", 512) = 31
mkdir("/opt/defender-spyder-workspace/.claw/sessions/c735e81ff5c567f3", 0777) = -1 EEXIST (File exists)
statx(AT_FDCWD, "/opt/defender-spyder-workspace/.claw/sessions/c735e81ff5c567f3", AT_STATX_SYNC_AS_STAT, STATX_ALL, {stx_mask=STATX_ALL, stx_attributes=0, stx_mode=S_IFDIR|0755, stx_size=6, ...}) = 0
getcwd("/opt/defender-spyder-workspace", 512) = 31
openat(AT_FDCWD, "/home/cm/.claw.json", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/home/cm/.claw/settings.json", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/opt/defender-spyder-workspace/.claw.json", O_RDONLY|O_CLOEXEC) = 3
statx(3, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_ALL, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=56, ...}) = 0
read(3, "{\n  \"permissions\": {\n    \"defaul"..., 56) = 56
read(3, "", 32)                         = 0
close(3)                                = 0
openat(AT_FDCWD, "/opt/defender-spyder-workspace/.claw/settings.json", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/opt/defender-spyder-workspace/.claw/settings.local.json", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/root/claw/claw-code/rust/crates/plugins/bundled", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = -1 EACCES (Permission denied)
write(2, "error: ", 7error: )                  = 7
write(2, "Permission denied (os error 13)", 31Permission denied (os error 13)) = 31
write(2, "\n\nRun `claw --help` for usage.\n", 31

Run `claw --help` for usage.
) = 31
sigaltstack({ss_sp=NULL, ss_flags=SS_DISABLE, ss_si...

</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

*This pull request was created from Copilot chat.*
>