### PR TITLE
build: docker compose + dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Keep docker build context small (Windows-friendly).
+.git
+.github
+**/target
+**/.claw-rag
+**/.claw
+**/.claude
+**/.cursor
+**/node_modules
+**/dist
+**/build
+**/*.log
+**/*.tmp
+**/*.sqlite
+**/*.sqlite-wal
+**/*.sqlite-shm
+**/.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    environment:
+      QDRANT__SERVICE__GRPC_PORT: "6334"
+    volumes:
+      - qdrant-storage:/qdrant/storage
+
+  rag-serve:
+    build:
+      context: ./rust
+      dockerfile: crates/claw-rag-service/Dockerfile
+    command: ["serve", "--db", "/data/index.sqlite"]
+    environment:
+      # Use mock embeddings by default for local dev; override in your shell for real providers.
+      CLAW_RAG_MOCK_PROVIDERS: "1"
+      CLAW_RAG_DB: "/data/index.sqlite"
+      CLAW_RAG_HOST: "0.0.0.0"
+      CLAW_RAG_QDRANT_URL: "http://qdrant:6334"
+      CLAW_RAG_QDRANT_COLLECTION: "claw_rag_chunks"
+    ports:
+      - "8787:8787"
+    depends_on:
+      - qdrant
+    volumes:
+      - rag-data:/data
+
+  rag-ingest:
+    build:
+      context: ./rust
+      dockerfile: crates/claw-rag-service/Dockerfile
+    command: ["ingest", "--db", "/data/index.sqlite"]
+    environment:
+      CLAW_RAG_MOCK_PROVIDERS: "1"
+      CLAW_RAG_DB: "/data/index.sqlite"
+      CLAW_RAG_QDRANT_URL: "http://qdrant:6334"
+      CLAW_RAG_QDRANT_COLLECTION: "claw_rag_chunks"
+    depends_on:
+      - qdrant
+    volumes:
+      - rag-data:/data
+      # Mount example workspace roots under /workspaces
+      - ./:/workspaces/main:ro
+
+volumes:
+  qdrant-storage:
+  rag-data:

--- a/rust/.dockerignore
+++ b/rust/.dockerignore
@@ -1,0 +1,15 @@
+# This .dockerignore applies to docker-compose build context: ./rust
+target
+**/target
+.claw
+.claw-rag
+.claude
+node_modules
+dist
+build
+*.log
+*.tmp
+*.sqlite
+*.sqlite-wal
+*.sqlite-shm
+.DS_Store


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` for local service runs.
- Add `.dockerignore` (root + `rust/`) to reduce build context and avoid accidental large uploads.

## Test plan
- [ ] Run `docker compose up --build` from repo root.
- [ ] Confirm build context stays small (no `target/`, local indexes, etc.).