### PR TITLE
Fix skills subcommand JSON help dispatch

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -2420,6 +2420,13 @@ pub fn handle_skills_slash_command_json(args: Option<&str>, cwd: &Path) -> std::
 pub fn classify_skills_slash_command(args: Option<&str>) -> SkillSlashDispatch {
     match normalize_optional_args(args) {
         None | Some("list" | "help" | "-h" | "--help") => SkillSlashDispatch::Local,
+        Some(args)
+            if args
+                .split_whitespace()
+                .any(|part| matches!(part, "-h" | "--help")) =>
+        {
+            SkillSlashDispatch::Local
+        }
         Some(args) if args == "install" || args.starts_with("install ") => {
             SkillSlashDispatch::Local
         }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -10143,6 +10143,47 @@ mod tests {
             }
         );
         assert_eq!(
+            parse_args(&[
+                "skills".to_string(),
+                "list".to_string(),
+                "--help".to_string(),
+                "--output-format".to_string(),
+                "json".to_string(),
+            ])
+            .expect("skills list help json should stay local"),
+            CliAction::Skills {
+                args: Some("list --help".to_string()),
+                output_format: CliOutputFormat::Json,
+            }
+        );
+        assert_eq!(
+            parse_args(&[
+                "skills".to_string(),
+                "show".to_string(),
+                "--help".to_string(),
+                "--output-format=json".to_string(),
+            ])
+            .expect("skills show help json should stay local"),
+            CliAction::Skills {
+                args: Some("show --help".to_string()),
+                output_format: CliOutputFormat::Json,
+            }
+        );
+        assert_eq!(
+            parse_args(&[
+                "skills".to_string(),
+                "missing-skill".to_string(),
+                "--help".to_string(),
+                "--output-format".to_string(),
+                "json".to_string(),
+            ])
+            .expect("missing skill help json should stay local"),
+            CliAction::Skills {
+                args: Some("missing-skill --help".to_string()),
+                output_format: CliOutputFormat::Json,
+            }
+        );
+        assert_eq!(
             parse_args(&["agents".to_string(), "--help".to_string()])
                 .expect("agents help should parse"),
             CliAction::Agents {

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -65,6 +65,33 @@ fn acp_guidance_emits_json_when_requested() {
 }
 
 #[test]
+fn skills_subcommand_help_json_is_bounded_and_static() {
+    let root = unique_temp_dir("skills-help-json");
+    fs::create_dir_all(&root).expect("temp dir should exist");
+
+    for args in [
+        &["skills", "list", "--help", "--output-format", "json"][..],
+        &["skills", "install", "--help", "--output-format", "json"][..],
+        &["skills", "show", "--help", "--output-format", "json"][..],
+        &[
+            "skills",
+            "missing-skill",
+            "--help",
+            "--output-format",
+            "json",
+        ][..],
+    ] {
+        let help = assert_json_command(&root, args);
+        assert_eq!(help["kind"], "skills");
+        assert_eq!(help["action"], "help");
+        assert!(help["usage"]["direct_cli"]
+            .as_str()
+            .expect("direct CLI usage")
+            .contains("claw skills"));
+    }
+}
+
+#[test]
 fn inventory_commands_emit_structured_json_when_requested() {
     let root = unique_temp_dir("inventory-json");
     fs::create_dir_all(&root).expect("temp dir should exist");


### PR DESCRIPTION
## Summary
- Keep `claw skills <subcommand> --help --output-format json` on the local skills help path instead of prompt/runtime invocation
- Preserve `skills help <topic>` skill invocation behavior
- Add regression coverage for list/install/show/missing-skill JSON help

## Tests
- `cargo fmt`
- `cargo test -p rusty-claude-cli skills_subcommand_help_json_is_bounded_and_static`
- `cargo test -p rusty-claude-cli removed_login_and_logout_subcommands_error_helpfully`
- `cargo test -p rusty-claude-cli parses_json_output_for_mcp_and_skills_commands`
- `cargo test -p rusty-claude-cli --test output_format_contract`

## Reproduction
- Before: `timeout --kill-after=1s 8s cargo run --quiet --bin claw -- skills list --help --output-format json` exited 124 with empty stdout/stderr in this fresh worktree while the binary built.
- After build: `timeout --kill-after=1s 8s ./target/debug/claw skills list --help --output-format json` exits 0 with bounded skills help JSON.