### PR TITLE
test(output_format_contract): add plugins json coverage to inventory_commands test

### DIFF
--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -105,6 +105,18 @@ fn inventory_commands_emit_structured_json_when_requested() {
     let skills = assert_json_command(&root, &["--output-format", "json", "skills"]);
     assert_eq!(skills["kind"], "skills");
     assert_eq!(skills["action"], "list");
+
+    let plugins = assert_json_command(&root, &["--output-format", "json", "plugins"]);
+    assert_eq!(plugins["kind"], "plugin");
+    assert_eq!(plugins["action"], "list");
+    assert!(
+        plugins["reload_runtime"].is_boolean(),
+        "plugins reload_runtime should be a boolean"
+    );
+    assert!(
+        plugins["target"].is_null(),
+        "plugins target should be null when no plugin is targeted"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Adds four assertions to the existing `inventory_commands_emit_structured_json_when_requested` test in `output_format_contract.rs`:

- `kind == "plugin"`
- `action == "list"`
- `reload_runtime` is boolean
- `target` is null when no plugin is targeted

`claw plugins --output-format json` was the only major JSON surface with zero contract coverage. Every other surface (agents, mcp, skills, status, sandbox, doctor, help, version, acp, bootstrap-plan, system-prompt, init, diff, config) already had assertions.

Local test run: `cargo test -p rusty-claude-cli -- inventory_commands_emit_structured_json_when_requested` → 2 passed (0 failed).