### PR TITLE
fix: support /plugins slash command in resume mode

### DIFF
--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3546,9 +3546,10 @@ fn run_resume_command(
             })
         }
         SlashCommand::Plugins { action, target } => {
-            // Only list/help are supported in resume mode (no runtime to reload)
+            // Only list is supported in resume mode (no runtime to reload)
             match action.as_deref() {
-                Some("install") | Some("uninstall") | Some("enable") | Some("disable") => {
+                Some("install") | Some("uninstall") | Some("enable") | Some("disable")
+                | Some("update") => {
                     return Err(
                         "resumed /plugins mutations are interactive-only; start `claw` and run `/plugins` in the REPL".into(),
                     );

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3559,7 +3559,8 @@ fn run_resume_command(
             let loader = ConfigLoader::default_for(&cwd);
             let runtime_config = loader.load()?;
             let mut manager = build_plugin_manager(&cwd, &loader, &runtime_config);
-            let result = handle_plugins_slash_command(action.as_deref(), target.as_deref(), &mut manager)?;
+            let result =
+                handle_plugins_slash_command(action.as_deref(), target.as_deref(), &mut manager)?;
             let action_str = action.as_deref().unwrap_or("list");
             let json = serde_json::json!({
                 "kind": "plugin",

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3545,6 +3545,35 @@ fn run_resume_command(
                 json: Some(handle_skills_slash_command_json(args.as_deref(), &cwd)?),
             })
         }
+        SlashCommand::Plugins { action, target } => {
+            // Only list/help are supported in resume mode (no runtime to reload)
+            match action.as_deref() {
+                Some("install") | Some("uninstall") | Some("enable") | Some("disable") => {
+                    return Err(
+                        "resumed /plugins mutations are interactive-only; start `claw` and run `/plugins` in the REPL".into(),
+                    );
+                }
+                _ => {}
+            }
+            let cwd = env::current_dir()?;
+            let loader = ConfigLoader::default_for(&cwd);
+            let runtime_config = loader.load()?;
+            let mut manager = build_plugin_manager(&cwd, &loader, &runtime_config);
+            let result = handle_plugins_slash_command(action.as_deref(), target.as_deref(), &mut manager)?;
+            let action_str = action.as_deref().unwrap_or("list");
+            let json = serde_json::json!({
+                "kind": "plugin",
+                "action": action_str,
+                "target": target,
+                "message": &result.message,
+                "reload_runtime": result.reload_runtime,
+            });
+            Ok(ResumeCommandOutcome {
+                session: session.clone(),
+                message: Some(result.message),
+                json: Some(json),
+            })
+        }
         SlashCommand::Doctor => {
             let report = render_doctor_report()?;
             Ok(ResumeCommandOutcome {
@@ -3631,7 +3660,6 @@ fn run_resume_command(
         | SlashCommand::Model { .. }
         | SlashCommand::Permissions { .. }
         | SlashCommand::Session { .. }
-        | SlashCommand::Plugins { .. }
         | SlashCommand::Login
         | SlashCommand::Logout
         | SlashCommand::Vim

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -398,7 +398,6 @@ fn resumed_inventory_commands_emit_structured_json_when_requested() {
         "count must be a number, not a text render"
     );
 
-
     let plugins = assert_json_command_with_env(
         &root,
         &[

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -397,6 +397,35 @@ fn resumed_inventory_commands_emit_structured_json_when_requested() {
         agents["count"].is_number(),
         "count must be a number, not a text render"
     );
+
+
+    let plugins = assert_json_command_with_env(
+        &root,
+        &[
+            "--output-format",
+            "json",
+            "--resume",
+            session_path.to_str().expect("utf8 session path"),
+            "/plugins",
+        ],
+        &[
+            (
+                "CLAW_CONFIG_HOME",
+                config_home.to_str().expect("utf8 config home"),
+            ),
+            ("HOME", home.to_str().expect("utf8 home")),
+        ],
+    );
+    assert_eq!(plugins["kind"], "plugin");
+    assert_eq!(plugins["action"], "list");
+    assert!(
+        plugins["reload_runtime"].is_boolean(),
+        "plugins reload_runtime should be a boolean"
+    );
+    assert!(
+        plugins["target"].is_null(),
+        "plugins target should be null when no plugin is targeted"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Bug

`claw --resume session.jsonl /plugins --output-format json` returns:
```json
{"command":"/plugins","error":"unsupported resumed slash command","type":"error"}
```

But `/mcp` and `/skills` both work in resume mode. The `/plugins` handler exists in the REPL and non-resume CLI paths — it was just never wired into `run_resume_command`.

## Fix

- Move `SlashCommand::Plugins` out of the unsupported catch-all in `run_resume_command`
- Add a handler arm that calls `handle_plugins_slash_command` for list/help
- Mutation actions (install/uninstall/enable/disable) are rejected with a clear error since there is no runtime to reload in resume mode
- Add `/plugins` coverage to `resumed_inventory_commands_emit_structured_json_when_requested` test

## Verification

```
cargo test -p rusty-claude-cli -- resumed_inventory_commands
# 1 passed, 0 failed
```

**Before:** exit 1, error envelope
**After:** exit 0, `{kind: "plugin", action: "list", reload_runtime: false, target: null, message: "..."}`