### PR TITLE
fix(resume): emit structured JSON for /agents --output-format json

### DIFF
--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3523,10 +3523,10 @@ fn run_resume_command(
             Ok(ResumeCommandOutcome {
                 session: session.clone(),
                 message: Some(handle_agents_slash_command(args.as_deref(), &cwd)?),
-                json: Some(serde_json::json!({
-                    "kind": "agents",
-                    "text": handle_agents_slash_command(args.as_deref(), &cwd)?,
-                })),
+                json: Some(
+                    serde_json::to_value(handle_agents_slash_command_json(args.as_deref(), &cwd)?)
+                        .unwrap_or_else(|_| serde_json::json!(null)),
+                ),
             })
         }
         SlashCommand::Skills { args } => {

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -360,6 +360,34 @@ fn resumed_inventory_commands_emit_structured_json_when_requested() {
     assert_eq!(skills["action"], "list");
     assert!(skills["summary"]["total"].is_number());
     assert!(skills["skills"].is_array());
+
+    let agents = assert_json_command_with_env(
+        &root,
+        &[
+            "--output-format",
+            "json",
+            "--resume",
+            session_path.to_str().expect("utf8 session path"),
+            "/agents",
+        ],
+        &[
+            (
+                "CLAW_CONFIG_HOME",
+                config_home.to_str().expect("utf8 config home"),
+            ),
+            ("HOME", home.to_str().expect("utf8 home")),
+        ],
+    );
+    assert_eq!(agents["kind"], "agents");
+    assert_eq!(agents["action"], "list");
+    assert!(
+        agents["agents"].is_array(),
+        "agents field must be a JSON array"
+    );
+    assert!(
+        agents["count"].is_number(),
+        "count must be a number, not a text render"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Resumed `/agents --output-format json` returned a human-readable text render wrapped in a JSON envelope instead of the actual structured agent list.

```
claw --resume latest /agents --output-format json
# exits 0, but prints human text ("Agents", "20 active agents", grouped rows)
# ignores --output-format json
```

Root cause: `run_resume_command` for `SlashCommand::Agents` called `handle_agents_slash_command` (text renderer) for the `json` outcome field instead of `handle_agents_slash_command_json`.

## Fix

Use `handle_agents_slash_command_json` for the `json` field, matching the pattern already used by `/skills` and `/plugins`.

## Test

Extended `resumed_inventory_commands_emit_structured_json_when_requested` to cover `/agents`:
- `kind == "agents"`
- `action == "list"`
- `agents` is a JSON array
- `count` is a number (not a text render)

Pinpoint: ROADMAP #500