### PR TITLE
fix(config): emit section and section_value in JSON output for config subcommands

### DIFF
--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -6207,7 +6207,7 @@ fn render_config_report(section: Option<&str>) -> Result<String, Box<dyn std::er
 }
 
 fn render_config_json(
-    _section: Option<&str>,
+    section: Option<&str>,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let cwd = env::current_dir()?;
     let loader = ConfigLoader::default_for(&cwd);
@@ -6240,13 +6240,52 @@ fn render_config_json(
         })
         .collect();
 
-    Ok(serde_json::json!({
+    let base = serde_json::json!({
         "kind": "config",
         "cwd": cwd.display().to_string(),
         "loaded_files": loaded_paths.len(),
         "merged_keys": runtime_config.merged().len(),
         "files": files,
-    }))
+    });
+
+    if let Some(section) = section {
+        let section_rendered: Option<String> = match section {
+            "env" => runtime_config.get("env").map(|v| v.render()),
+            "hooks" => runtime_config.get("hooks").map(|v| v.render()),
+            "model" => runtime_config.get("model").map(|v| v.render()),
+            "plugins" => runtime_config
+                .get("plugins")
+                .or_else(|| runtime_config.get("enabledPlugins"))
+                .map(|v| v.render()),
+            other => {
+                return Ok(serde_json::json!({
+                    "kind": "config",
+                    "section": other,
+                    "ok": false,
+                    "error": format!("Unsupported config section '{other}'. Use env, hooks, model, or plugins."),
+                    "cwd": cwd.display().to_string(),
+                    "loaded_files": loaded_paths.len(),
+                    "files": files,
+                }));
+            }
+        };
+        // Parse the rendered JSON string back into serde_json::Value so that
+        // section_value is a real JSON object/array in the envelope, not a quoted string.
+        let section_value: serde_json::Value = section_rendered
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or(serde_json::Value::Null);
+        let mut obj = base;
+        let map = obj.as_object_mut().expect("base is object");
+        map.insert(
+            "section".to_string(),
+            serde_json::Value::String(section.to_string()),
+        );
+        map.insert("section_value".to_string(), section_value);
+        return Ok(obj);
+    }
+
+    Ok(base)
 }
 
 fn render_memory_report() -> Result<String, Box<dyn std::error::Error>> {

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -396,6 +396,44 @@ fn resumed_version_and_init_emit_structured_json_when_requested() {
     assert!(root.join("CLAUDE.md").exists());
 }
 
+#[test]
+fn config_section_json_emits_section_and_value() {
+    let root = unique_temp_dir("config-section-json");
+    fs::create_dir_all(&root).expect("temp dir should exist");
+
+    // Without a section: should return base envelope (no section field).
+    let base = assert_json_command(&root, &["--output-format", "json", "config"]);
+    assert_eq!(base["kind"], "config");
+    assert!(base["loaded_files"].is_number());
+    assert!(base["merged_keys"].is_number());
+    assert!(
+        base.get("section").is_none(),
+        "no section field without section arg"
+    );
+
+    // With a known section: should add section + section_value fields.
+    for section in &["model", "env", "hooks", "plugins"] {
+        let result = assert_json_command(&root, &["--output-format", "json", "config", section]);
+        assert_eq!(result["kind"], "config", "section={section}");
+        assert_eq!(
+            result["section"].as_str(),
+            Some(*section),
+            "section field must match requested section, got {result:?}"
+        );
+        assert!(
+            result.get("section_value").is_some(),
+            "section_value field must be present for section={section}"
+        );
+    }
+
+    // With an unsupported section: should return ok:false + error field.
+    let bad = assert_json_command(&root, &["--output-format", "json", "config", "unknown"]);
+    assert_eq!(bad["kind"], "config");
+    assert_eq!(bad["ok"], false);
+    assert!(bad["error"].as_str().is_some());
+    assert!(bad["section"].as_str().is_some());
+}
+
 fn assert_json_command(current_dir: &Path, args: &[&str]) -> Value {
     assert_json_command_with_env(current_dir, args, &[])
 }


### PR DESCRIPTION
## Problem

`claw config model --output-format json` returned the same envelope as `claw config --output-format json` — the section argument was parsed but discarded (`_section` parameter in `render_config_json`).

```json
// before: config model → identical to config (no section field)
{ "kind": "config", "merged_keys": 1, "loaded_files": 1, "files": [...] }

// after: config model
{ "kind": "config", "section": "model", "section_value": null,
  "merged_keys": 1, "loaded_files": 1, "files": [...] }
```

The text path (`render_config_report`) already handled section correctly; only the JSON path was broken.

## Fix

`render_config_json` now:
- Passes `section` through (was `_section`)
- Looks up the section value via `runtime_config.get()`, converting the internal `JsonValue` to `serde_json::Value` via `render()`+parse
- Emits `section` (string) and `section_value` (parsed JSON value or null)
- Returns `ok:false` + `error` for unsupported section tokens

## Test

`config_section_json_emits_section_and_value`: asserts no `section` field without section arg; `section`+`section_value` present for all known sections; `ok:false`+`error` for unknown section.

Pinpoint: ROADMAP #126