### PR TITLE
fix(version): add build_date and executable_path to version JSON output

### DIFF
--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -2627,12 +2627,15 @@ fn print_version(output_format: CliOutputFormat) -> Result<(), Box<dyn std::erro
 }
 
 fn version_json_value() -> serde_json::Value {
+    let executable_path = env::current_exe().ok().map(|p| p.display().to_string());
     json!({
         "kind": "version",
         "message": render_version_report(),
         "version": VERSION,
         "git_sha": GIT_SHA,
         "target": BUILD_TARGET,
+        "build_date": DEFAULT_DATE,
+        "executable_path": executable_path,
     })
 }
 

--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -30,6 +30,15 @@ fn version_emits_json_when_requested() {
     let parsed = assert_json_command(&root, &["--output-format", "json", "version"]);
     assert_eq!(parsed["kind"], "version");
     assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+    // Provenance fields must be present for binary identification (#507).
+    assert!(
+        parsed["build_date"].is_string(),
+        "build_date must be a string in version JSON"
+    );
+    assert!(
+        parsed["executable_path"].is_string(),
+        "executable_path must be a string in version JSON so callers can identify which binary is running"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`claw version --output-format json` was missing `build_date` and `executable_path`, making it impossible to identify which binary is running or correlate it with a specific build.

```json
// before
{ "kind": "version", "version": "0.1.0", "git_sha": null, "target": null }

// after
{ "kind": "version", "version": "0.1.0", "git_sha": "39bae88f",
  "target": "aarch64-apple-darwin", "build_date": "2026-05-04",
  "executable_path": "/usr/local/bin/claw" }
```

Both fields were already emitted in the human-readable text output but absent from the JSON envelope. `build_date` is compile-time constant (`DEFAULT_DATE`); `executable_path` is `std::env::current_exe()` at runtime.

## Test

Extended `version_emits_json_when_requested` to assert `build_date` and `executable_path` are strings.

Pinpoint: ROADMAP #507