### PR TITLE
fix(tests): isolate CLAW_CONFIG_HOME in resumed_status JSON test

### DIFF
--- a/rust/crates/rusty-claude-cli/tests/resume_slash_commands.rs
+++ b/rust/crates/rusty-claude-cli/tests/resume_slash_commands.rs
@@ -227,6 +227,8 @@ fn resumed_status_command_emits_structured_json_when_requested() {
     // given
     let temp_dir = unique_temp_dir("resume-status-json");
     fs::create_dir_all(&temp_dir).expect("temp dir should exist");
+    let config_home = temp_dir.join("config-home");
+    fs::create_dir_all(&config_home).expect("isolated config home should exist");
     let session_path = temp_dir.join("session.jsonl");
 
     let mut session = workspace_session(&temp_dir);
@@ -238,7 +240,9 @@ fn resumed_status_command_emits_structured_json_when_requested() {
         .expect("session should persist");
 
     // when
-    let output = run_claw(
+    // Use an isolated CLAW_CONFIG_HOME so ~/.claw/settings.json is not loaded,
+    // which would cause loaded_config_files to be non-zero (#65).
+    let output = run_claw_with_env(
         &temp_dir,
         &[
             "--output-format",
@@ -247,6 +251,7 @@ fn resumed_status_command_emits_structured_json_when_requested() {
             session_path.to_str().expect("utf8 path"),
             "/status",
         ],
+        &[("CLAW_CONFIG_HOME", config_home.to_str().expect("utf8 path"))],
     );
 
     // then


### PR DESCRIPTION
## Problem

`resumed_status_command_emits_structured_json_when_requested` was reading the real `~/.claw/settings.json` on developer machines, causing:
```
assert_eq!(parsed["workspace"]["loaded_config_files"].as_u64(), Some(0))
// fails with: left: Some(1) right: Some(0)
```

This was a pre-existing `main` failure blocking PRs #2973, #2988, #2990 from showing clean CI.

## Root Cause

Unlike other tests (e.g. `resumed_config_command_loads_settings_files`), this test did not pass an isolated `CLAW_CONFIG_HOME` env var to `run_claw`. So claw fell back to `HOME` and loaded whatever `~/.claw/settings.json` the developer had present.

## Fix

Create a temp config-home dir and pass it as `CLAW_CONFIG_HOME` via `run_claw_with_env`. This gives the assertion a clean 0-file baseline, consistent with all other test isolation patterns.

## Test
```
cargo test -p rusty-claude-cli -- --test-thread=1
# all 12 tests pass
```

Closes ROADMAP #65.