### PR TITLE
fix(permissions): return guidance for multi-word forms instead of falling through to LLM

### DIFF
--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -926,6 +926,14 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             }
             Ok(CliAction::Diff { output_format })
         }
+        // `claw permissions <mode>` falls through to the LLM when called
+        // with a subcommand argument because parse_single_word_command_alias
+        // only intercepts the bare single-word form. Catch all multi-word
+        // forms here and return a structured guidance error so no network
+        // call or session is created.
+        "permissions" => Err(format!(
+            "`claw permissions` is a slash command. Start `claw` and run `/permissions` inside the REPL.\n  Usage  /permissions [read-only|workspace-write|danger-full-access]"
+        )),
         "skills" => {
             let args = join_optional_args(&rest[1..]);
             match classify_skills_slash_command(args.as_deref()) {


### PR DESCRIPTION
## Problem

`claw permissions list`, `claw permissions allow bash`, `claw permissions deny bash` etc. all fall through to the prompt/LLM path, calling the Anthropic API and returning auth errors. Only the bare single-word form `claw permissions` was intercepted by `bare_slash_command_guidance`.

## Root Cause

`parse_single_word_command_alias` guards on `rest.len() != 1` and returns `None` for multi-word forms, then `parse_subcommand` had no `"permissions"` arm so those forms hit `_other => CliAction::Prompt`.

Same root cause cluster as `claw plugin list` / `claw marketplace` fixed in #2993.

## Fix

Add a `"permissions"` arm in `parse_subcommand` returning a structured guidance `Err` with the correct usage hint.

## Verification

All 6 invocation forms tested — all exit 1 with `kind:unknown` guidance JSON, zero sessions created:
```
claw permissions              → guidance exit:1 ✅
claw permissions list         → guidance exit:1 ✅
claw permissions read-only    → guidance exit:1 ✅
claw permissions allow bash   → guidance exit:1 ✅
claw permissions deny bash    → guidance exit:1 ✅
claw permissions workspace-write → guidance exit:1 ✅
```