### PR TITLE
bump rustls-webpki to 0.103.13

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1430,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- bump `rustls-webpki` 0.103.10 -> 0.103.13 in `rust/Cargo.lock`

## Why
`rustls-webpki 0.103.10` is reachable via `reqwest -> hyper-rustls -> rustls -> rustls-webpki` and has three open advisories:

- RUSTSEC-2026-0098: name constraints for URI names were incorrectly accepted
- RUSTSEC-2026-0099: name constraints accepted for certificates asserting a wildcard name
- RUSTSEC-2026-0104: reachable panic in CRL parsing

0.103.13 is the first patched release in the 0.103.x line. Lockfile-only bump, no Cargo.toml changes needed since the existing constraint already accepts it.

## Testing
- cargo build --workspace --all-targets
- cargo test --workspace (1117 passed, 0 failed)
- cargo audit (the three rustls-webpki advisories no longer fire)

## Notes
The remaining audit output is unrelated to this PR (`bincode` and `yaml-rust` are unmaintained advisories; the `telemetry 0.1.0` hit is a name collision between this workspace's local `telemetry` crate and an unrelated published crate that shares its name+version).

Architectural permission-model issues spotted during the same audit pass are filed separately as #3007 and are not addressed here.