### PR TITLE
Document TweetClaw skill install example

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -413,6 +413,27 @@ cd rust
 ./target/debug/claw system-prompt --cwd .. --date 2026-04-04
 ```
 
+## Install an external skill
+
+`claw skills install <path>` accepts a local skill directory that contains
+`SKILL.md` or a standalone markdown file. This is useful when a companion
+repository ships a skill prompt that should be available through `/skills`.
+
+For example, install TweetClaw as an X/Twitter automation skill:
+
+```bash
+# From a parent directory that contains claw-code
+git clone https://github.com/Xquik-dev/tweetclaw
+cd claw-code/rust
+./target/debug/claw skills install ../../tweetclaw/skills/tweetclaw
+./target/debug/claw skills show tweetclaw
+```
+
+TweetClaw gives `claw` users a local skill guide for OpenClaw/Xquik workflows
+such as tweet search, reply search, follower export, monitors, webhooks, and
+approval-gated posting. Configure any Xquik credentials outside the prompt and
+avoid pasting API keys into chat.
+
 ## Session management
 
 REPL turns are persisted under `.claw/sessions/` in the current workspace.


### PR DESCRIPTION
## Summary

- Documents the existing `claw skills install <path>` flow with a concrete external-skill example.
- Uses TweetClaw's `skills/tweetclaw` directory to show how a local `SKILL.md` source can be installed and inspected.
- Adds a short credential-safety note for Xquik configuration.

## Validation

- `git diff --check`
- Targeted secret-pattern scan on the touched diff
- Verified the referenced TweetClaw skill source exists locally

Docs-only change; no Rust build or test run.
