### PR TITLE
fix(render): restore trailing newlines stripped by markdown_to_ansi in stream

### DIFF
--- a/rust/crates/rusty-claude-cli/src/render.rs
+++ b/rust/crates/rusty-claude-cli/src/render.rs
@@ -609,7 +609,15 @@ impl MarkdownStreamState {
         let split = find_stream_safe_boundary(&self.pending)?;
         let ready = self.pending[..split].to_string();
         self.pending.drain(..split);
-        Some(renderer.markdown_to_ansi(&ready))
+        let rendered = renderer.markdown_to_ansi(&ready);
+        // markdown_to_ansi strips trailing newlines via trim_end(); restore them
+        // so consecutive streamed chunks are separated in the terminal output.
+        let trailing = if ready.ends_with("\n\n") { "\n\n" } else { "\n" };
+        Some(if rendered.ends_with('\n') {
+            rendered
+        } else {
+            rendered + trailing
+        })
     }
 
     #[must_use]


### PR DESCRIPTION
## Summary

`MarkdownStreamState::push` calls `markdown_to_ansi` on each ready chunk, but `render_markdown` strips trailing newlines via `trim_end()` (see `render.rs` line 270). When the next streamed chunk arrives, its rendered output runs into the tail of the previous chunk in the terminal — adjacent paragraphs / list items / code blocks visibly merge into each other.

This PR restores the trailing newline(s) on the rendered output when the input chunk had them, matching the input's level of trailing whitespace (`\n` vs `\n\n`). `flush()` is unaffected since it returns the final chunk where trailing whitespace is irrelevant.

## Diff

```rust
 pub fn push(&mut self, renderer: &TerminalRenderer, delta: &str) -> Option<String> {
     self.pending.push_str(delta);
     let split = find_stream_safe_boundary(&self.pending)?;
     let ready = self.pending[..split].to_string();
     self.pending.drain(..split);
-    Some(renderer.markdown_to_ansi(&ready))
+    let rendered = renderer.markdown_to_ansi(&ready);
+    // markdown_to_ansi strips trailing newlines via trim_end(); restore them
+    // so consecutive streamed chunks are separated in the terminal output.
+    let trailing = if ready.ends_with("\n\n") { "\n\n" } else { "\n" };
+    Some(if rendered.ends_with('\n') {
+        rendered
+    } else {
+        rendered + trailing
+    })
 }
```

## Repro

Any OpenAI-compatible streaming endpoint whose deltas are separated by `\n` reproduces this — most providers do. Visual repro: stream a multi-line response with numbered lists or fenced code blocks and observe items concatenating without a visible separator.

## Test plan

- [x] `cargo check --workspace` clean
- [ ] Existing render tests: `cargo test -p rusty-claude-cli`
- [ ] Manual: stream a multi-line response through the CLI, observe newlines preserved between rendered chunks