### PR TITLE
feat(providers): add "local/" routing prefix for OpenAI-compatible local servers

### DIFF
--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -254,7 +254,10 @@ pub fn metadata_for_model(model: &str) -> Option<ProviderMetadata> {
     // route to the correct provider regardless of which auth env vars are set.
     // Without this, detect_provider_kind falls through to the auth-sniffer
     // order and misroutes to Anthropic if ANTHROPIC_API_KEY is present.
-    if canonical.starts_with("openai/") || canonical.starts_with("gpt-") {
+    if canonical.starts_with("openai/")
+        || canonical.starts_with("local/")
+        || canonical.starts_with("gpt-")
+    {
         return Some(ProviderMetadata {
             provider: ProviderKind::OpenAi,
             auth_env: "OPENAI_API_KEY",

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -939,7 +939,7 @@ fn wire_model_for_base_url<'a>(
         return Cow::Borrowed(&model[pos + 1..]);
     }
 
-    if matches!(lowered_prefix.as_str(), "xai" | "grok" | "qwen" | "kimi") {
+    if matches!(lowered_prefix.as_str(), "local" | "xai" | "grok" | "qwen" | "kimi") {
         return Cow::Borrowed(&model[pos + 1..]);
     }
 


### PR DESCRIPTION
## Summary

A common deployment is running an OpenAI-compatible inference server locally — Ollama, LM Studio, vLLM, llama.cpp — and routing claw-code's OpenAI provider client at it via `OPENAI_BASE_URL`.

The obvious model id formats actively misroute today:

- `qwen/qwen3:14b` or `qwen3-coder` → `metadata_for_model` maps the qwen family to DashScope (`DASHSCOPE_API_KEY`, `dashscope.aliyuncs.com`). A user serving Qwen3 locally on Ollama is silently routed to Alibaba's cloud.
- `kimi/kimi-k2.5` → same DashScope routing.
- `grok-*` → routes to xAI.

The existing `openai/` prefix would work as a workaround, but mentally conflates "this is my local Qwen3" with "the OpenAI API itself", and a user who *does* want the existing OpenRouter behaviour (slug preserved on the wire for `openai/...`) can't have it both ways.

This PR adds `local/` as an explicit routing prefix that says "this is a local OpenAI-compatible server, route as OpenAI client, strip the prefix on the wire". Routing semantics are identical to `openai/`: `OpenAi` provider, `OPENAI_API_KEY` (typically an unused placeholder for local servers), `OPENAI_BASE_URL`.

## Diff

```rust
// providers/mod.rs
-if canonical.starts_with("openai/") || canonical.starts_with("gpt-") {
+if canonical.starts_with("openai/")
+    || canonical.starts_with("local/")
+    || canonical.starts_with("gpt-")
+{
     return Some(ProviderMetadata { provider: ProviderKind::OpenAi, ... });
 }

// providers/openai_compat.rs (wire_model_for_base_url)
-if matches!(lowered_prefix.as_str(), "xai" | "grok" | "qwen" | "kimi") {
+if matches!(lowered_prefix.as_str(), "local" | "xai" | "grok" | "qwen" | "kimi") {
     return Cow::Borrowed(&model[pos + 1..]);
 }
```

Two places only — both pure additions.

**No change to `strip_routing_prefix`** — it's `#[allow(dead_code)]` and only referenced from its own unit tests; adding `local` there would be cosmetic.

**No change to the OpenAI gateway slug preservation logic** used by OpenRouter and similar gateways with a non-default `OPENAI_BASE_URL` — `openai/...` behaviour stays exactly as upstream.

## Example

```bash
export OPENAI_BASE_URL=http://localhost:11434/v1
export OPENAI_API_KEY=ollama-placeholder
claw --model local/qwen3:14b "..."
```

Wire request: `POST $OPENAI_BASE_URL/chat/completions` with `model=qwen3:14b`. No misrouting to DashScope.

## Test plan

- [x] `cargo check --workspace` clean
- [ ] Existing provider tests: `cargo test -p api`
- [ ] Manual: route `local/qwen3:14b` against a local Ollama, verify the request goes to the local server with bare model id on the wire

## Companion discussion

A separate issue (#3045) covers two related open questions: `<think>...</think>` block filtering in streamed output, and whether the `openai/`-slug preservation logic should remain non-configurable once `local/` is available. Posted separately because both involve tradeoffs upstream may want to weigh in on before code lands.
