### PR TITLE
Flatten prior compaction highlights directly into the top-level list (prefixed with `-`), while keeping the current round’s highlights under `- Newly compacted context:`

### DIFF
--- a/rust/crates/runtime/src/compact.rs
+++ b/rust/crates/runtime/src/compact.rs
@@ -291,13 +291,11 @@ fn merge_compact_summaries(existing_summary: Option<&str>, new_summary: &str) ->
 
     let mut lines = vec!["<summary>".to_string(), "Conversation summary:".to_string()];
 
+    // Flatten prior highlights directly — do NOT re-nest them under
+    // "- Previously compacted context:" or the nesting compounds with each
+    // compaction cycle, inflating the summary by ~depth * overhead per turn.
     if !previous_highlights.is_empty() {
-        lines.push("- Previously compacted context:".to_string());
-        lines.extend(
-            previous_highlights
-                .into_iter()
-                .map(|line| format!("  {line}")),
-        );
+        lines.extend(previous_highlights.into_iter().map(|line| format!("- {line}")));
     }
 
     if !new_highlights.is_empty() {


### PR DESCRIPTION
if !previous_highlights.is_empty() {
    lines.extend(previous_highlights.into_iter().map(|line| format!("- {line}")));
}

This makes compaction summary size O(depth) rather than O(depth²) and nesting depth stays at 1 regardless of how many compactions run.Testing

• Compaction runs cleanly in a live session
• Session file nesting depth confirmed at 1 after multiple compaction cycles
• No regression in `compact_session` unit testsCloses #3050 


## Bug: Compaction summary nesting causes context window inflation

### Issue
**See [#3050](https://github.com/ultraworkers/claw-code/issues/3050)**

When Claw Code performs context compaction, the `build_compact_summary` function in `rust/crates/runtime/src/compact.rs` prepends the prior compaction summary under a `- Previously compacted context:` header:

```rust
if !previous_highlights.is_empty() {
    lines.push("- Previously compacted context:".to_string());
    lines.extend(
        previous_highlights
            .into_iter()
            .map(|line| format!("  {line}")),
    );
}
```

The problem: those `previous_highlights` were themselves generated by a prior call to `build_compact_summary`, which already contained a `- Previously compacted context:` entry from the round before that. Each compaction re-wraps the entire prior summary under a new nesting layer, so the summary grows as:

- **O(depth²)** in raw content — each level adds all prior levels plus overhead
- **O(depth)** in nesting depth — after N compactions the `<summary>` tag is N levels deep

After 20–30 compaction cycles in a long session, the session file contained summaries that were 30+ levels deep and 500KB+, causing error 2013 `context_window_blocked` crashes.

### Root Cause
`previous_highlights` already contains prior-compaction highlights that should not be re-nested — they were already incorporated into the flat summary structure. Re-wrapping them under a new `- Previously compacted context:` heading each cycle is the bug.

### Fix
Flatten prior compaction highlights directly into the top-level list (prefixed with `-`), while keeping the current round's highlights under `- Newly compacted context:`:

```rust
if !previous_highlights.is_empty() {
    lines.extend(previous_highlights.into_iter().map(|line| format!("- {line}")));
}
```

This makes compaction summary size **O(depth)** rather than **O(depth²)** and nesting depth stays at **1** regardless of how many compactions run.

### Testing
- Compaction runs cleanly in a live session
- Session file nesting depth confirmed at 1 after multiple compaction cycles
- No regression in `compact_session` unit tests

Closes #26

Disclaimer: This was written with the assistance of an LLM (Claw-Code/MiniMax-M2.7)