### PR TITLE
fix: unify user_agent to "clawd-rust-tools/0.1"

### DIFF
--- a/rust/crates/api/src/http_client.rs
+++ b/rust/crates/api/src/http_client.rs
@@ -71,7 +71,12 @@ pub fn build_http_client() -> Result<reqwest::Client, ApiError> {
 /// first outbound request instead of at construction time.
 #[must_use]
 pub fn build_http_client_or_default() -> reqwest::Client {
-    build_http_client().unwrap_or_else(|_| reqwest::Client::new())
+    build_http_client().unwrap_or_else(|_| {
+        reqwest::Client::builder()
+            .user_agent("clawd-rust-tools/0.1")
+            .build()
+            .expect("default client with user_agent should always succeed")
+    })
 }
 
 /// Build a `reqwest::Client` from an explicit [`ProxyConfig`]. Used by tests
@@ -81,7 +86,9 @@ pub fn build_http_client_or_default() -> reqwest::Client {
 /// and `https_proxy` fields and is registered as both an HTTP and HTTPS
 /// proxy so a single value can route every outbound request.
 pub fn build_http_client_with(config: &ProxyConfig) -> Result<reqwest::Client, ApiError> {
-    let mut builder = reqwest::Client::builder().no_proxy();
+    let mut builder = reqwest::Client::builder()
+        .no_proxy()
+        .user_agent("clawd-rust-tools/0.1");
 
     let no_proxy = config
         .no_proxy


### PR DESCRIPTION
## Summary
- adding missing and unify user_agent

## Anti-slop triage
- Classification: actionable-fix
- Evidence:  https://github.com/ultraworkers/claw-code/issues/3060
- Non-destructive review result: merge candidate

## Verification
- [x] Targeted tests/docs checks ran, or the gap is explicitly recorded.
- [x] `git diff --check` passes.
- [x] No live secrets, tokens, private logs, or unrelated generated churn are included.

## Resolution gate
- [x] If this PR resolves an issue, the issue number and fix evidence are linked.
- [x] If this PR should not merge, the rejection/defer rationale is evidence-backed and does not rely on vibes.
- [x] I did not merge/close remote PRs or issues from an automation lane without owner approval.
