### PR TITLE
fix: return conservative token limits for unspecified models

### DIFF
--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -640,7 +640,14 @@ pub fn model_token_limit(model: &str) -> Option<ModelTokenLimit> {
             max_output_tokens: 16_384,
             context_window_tokens: 256_000,
         }),
-        _ => None,
+        // Hotfix: Unknown models get conservative defaults to avoid crashes.
+        // Uses the minimum of known supported models: max_output_tokens: 16_384,
+        // context_window_tokens: 131_072. This may under-utilize the model's
+        // actual capabilities but hopefully ensures safer operation.
+        _ => Some(ModelTokenLimit {
+            max_output_tokens: 16_384,
+            context_window_tokens: 131_072,
+        }),
     }
 }
 


### PR DESCRIPTION
to avoid crashes

## Summary
- When working with a model not specially handled and coded in rust/crates/api/src/providers/mod.rs, the claw doesn't have an idea about the context window size. It will keep on growing without automatic compact, eventually lead of crash of the claw process when an error is thrown in the main.rs. The proper way fix is configure and don't hardcode any. However, we still need a reasonable default du jour to reduce chance of crashes. Thus it is picked to be max_output_tokens: 16_384, context_window_tokens: 131_072 as the minimum of each among the current specified models. While this doesn't prevent crash while working with much less capable models and may under-utilize much more capable models, it is a line in the sand currently needed before claw-code further optimize.

## Anti-slop triage
- Classification: actionable-fix
- Evidence:  https://github.com/ultraworkers/claw-code/issues/3062
- Non-destructive review result: merge candidate

## Verification
- [X] Targeted tests/docs checks ran, or the gap is explicitly recorded.
- [X] `git diff --check` passes.
- [X] No live secrets, tokens, private logs, or unrelated generated churn are included.

## Resolution gate
- [X] If this PR resolves an issue, the issue number and fix evidence are linked.
- [X] If this PR should not merge, the rejection/defer rationale is evidence-backed and does not rely on vibes.
- [X] I did not merge/close remote PRs or issues from an automation lane without owner approval.
