### PR TITLE
docs(roadmap): add #688 — sandbox help json lacks safety schema

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6428,3 +6428,48 @@ Original filing (2026-04-18): the session emitted `SessionStart hook (completed)
 
 
 450. **`prompt` emits `kind:"missing_credentials"` JSON on STDERR (not stdout), leaving stdout at 0 bytes — automation pattern `output=$(claw prompt hello --output-format json)` captures nothing on auth-absent failure; `doctor` correctly surfaces `auth.status:"warn"` with `api_key_present:false` but exposes no `prompt_ready:false` field that automation can check before invoking `prompt`** — dogfooded 2026-05-16 by Jobdori on `a35ee9a0` in response to Clawhip pinpoint nudge at `1505208225321062521`. Exact reproduction (isolated env, no creds, fresh git repo, HEAD `a35ee9a0`): `timeout 5 env -i HOME=$ISOLATED_HOME PATH=$PATH CLAW_CONFIG_HOME=$PROBE/.claw-cfg claw prompt hello --output-format json > stdout.txt 2> stderr.txt` → stdout = **0 bytes**, stderr = 195 bytes containing `{"error":"missing Anthropic credentials…","exit_code":1,"hint":null,"kind":"missing_credentials","type":"error"}`, exit code 1. Confirms Gaebal's `1505208553793781792` pinpoint that `prompt` timeout + zero bytes was the prior state — HEAD `a35ee9a0` now correctly exits 1 with `kind:"missing_credentials"` **but the envelope is still routed to stderr** (issue #447 class, same class as prior entries #422, #435). **Contrast with `doctor`:** `claw doctor --output-format json 2>/dev/null` succeeds to stdout with `checks[auth].status:"warn"`, `api_key_present:false`, `auth_token_present:false` — but the auth check has no `prompt_ready:false` field. Automation that gates on `doctor` before invoking `prompt` must re-derive readiness from `api_key_present && auth_token_present` — there is no single canonical boolean. **Three compound problems:** (a) **stdout-empty on `--output-format json` failure**: same class as #447; `prompt`'s error envelope goes to stderr, not stdout. The canonical automation idiom `if ! result=$(claw prompt "q" --output-format json); then echo "$result" | jq .kind; fi` sees `$result=""` on failure — the jq call gets nothing. All `--output-format json` error paths must route JSON to stdout per #447 contract; (b) **`doctor` missing `prompt_ready` field**: `doctor --output-format json` already knows auth is absent (`api_key_present:false`) but surfaces no derived `prompt_ready:bool` or `prompt_blocked_reason:string` field. Automation must infer readiness from `api_key_present || auth_token_present || legacy_*_present` — a 5-field OR across legacy fields that is fragile as auth mechanisms evolve. A single `prompt_ready:false` (with `prompt_blocked_reason:"auth_missing"`) inside the `auth` check would give downstream a stable contract; (c) **`claw prompt` with no auth does no preflight and fires straight at the API**: the preflight check that `doctor` runs (auth discovery) is not reused by `prompt` to emit a fast typed error before attempting the network call. Both Gaebal's pinpoint (prompt hanging silently on older HEAD) and the current behavior (prompt hitting auth gate after a brief API attempt) stem from the same root: prompt does not short-circuit at the point where `doctor` already knows auth is absent. If `doctor` can emit `kind:"doctor"` with `auth.status:"warn"` in ~20ms without a network call, `prompt` should emit `kind:"missing_credentials"` in the same window and output it to stdout. **Required fix shape:** (a) `prompt --output-format json` must write the `kind:"missing_credentials"` JSON envelope to **stdout**, not stderr — same fix as #447 for all error envelopes; (b) add `prompt_ready:bool` and `prompt_blocked_reason:string|null` to the `auth` check in `doctor --output-format json`; derive it as `api_key_present || auth_token_present || legacy_saved_oauth_present`; (c) `prompt` must run the credential preflight check (same codepath as doctor's auth check) before attempting any API call and emit `{"kind":"missing_credentials","prompt_blocked_reason":"auth_missing"}` on **stdout** with exit 1 if the check fails; (d) `--output-format json` stdout routing fix must cover: `prompt`, `session list` (cross-ref #449), `skills uninstall` (cross-ref #431), `resume` (cross-ref #435), `acp serve` (cross-ref #443) — the full `kind:"missing_credentials"` class; (e) regression test: `claw prompt hello --output-format json` with no creds writes JSON to stdout (0 bytes stderr), exits 1, `kind:"missing_credentials"`, in under 200ms (no network attempt). **Why this matters:** `prompt` is the primary consumer entry point. Auth-absent failure routing to stderr breaks every automation wrapper that captures `$(claw prompt ... --output-format json)`. The `doctor` preflight metadata gap means auth-readiness checks require parsing 5 legacy fields instead of reading one boolean. Cross-references #447 (all JSON error envelopes on stderr), #449 (session list hits auth gate), #431 (skills uninstall hits auth gate), #357 (auth gate on local ops cluster), #422 (exit-code parity). Source: Jobdori live dogfood, `a35ee9a0`, 2026-05-16.
+
+688. **`sandbox --help --output-format json` is JSON-valid on current main but message-only (`{kind, command, topic, message}`), while actual `sandbox --output-format json` exposes the safety/trust schema (`active`, `supported`, `enabled`, namespace/network/filesystem flags, `allowed_mounts`, `fallback_reason`, markers) that help does not describe; automation cannot discover sandbox-state fields or their intended semantics without invoking sandbox and reverse-engineering the payload** — dogfooded 2026-05-24 for the 23:30 Clawhip nudge at message `1508250775162196070`, reproduced on a freshly rebuilt current `origin/main` binary (`git_sha f8e1bb726`) from `/tmp/cc-probe-main-2130`. Active claw-code sessions: none.
+
+    Reproduction:
+
+    ```bash
+    $ env -i HOME=/tmp/iso43/home PATH=/usr/bin:/bin TERM=dumb \
+        claw sandbox --help --output-format json
+    {
+      "command": "sandbox",
+      "kind": "help",
+      "message": "Sandbox\n  Usage            claw sandbox [--output-format <format>]\n  Purpose          inspect the resolved sandbox and isolation state for the current directory\n  Output           namespace, network, filesystem, and fallback details\n  Formats          text (default), json\n  Related          /sandbox · claw status",
+      "topic": "sandbox"
+    }
+    ```
+
+    Actual sandbox JSON on the same binary exposes the trust-state fields:
+
+    ```bash
+    $ claw sandbox --output-format json | jq 'keys'
+    [
+      "active",
+      "active_namespace",
+      "active_network",
+      "allowed_mounts",
+      "enabled",
+      "fallback_reason",
+      "filesystem_active",
+      "filesystem_mode",
+      "in_container",
+      "kind",
+      "markers",
+      "requested_namespace",
+      "requested_network",
+      "supported"
+    ]
+    ```
+
+    Help does not expose any structured `output_fields`, `component_fields`, `mode_fields`, `local_only`, `requires_credentials:false`, `requires_provider_request:false`, `mutates_workspace:false`, or documented `active` aggregation semantics. This matters even more because #448 already shows the sandbox payload can carry confusing combinations such as `active:false` with `filesystem_active:true`; help should be the place where those fields are machine-described.
+
+    **Why distinct from existing items:** #448 is about contradictory sandbox state values and missing/implicit mount semantics in the actual payload. #688 is about help-schema discoverability: even if the payload values are corrected, `sandbox --help --output-format json` still gives automation only a prose `message` and no field contract. #325 is broad top-level help prose-wrapper; #687 is status schema help; #686 is doctor check-schema help. This one is sandbox-specific because sandbox is the safety/trust surface and its component-state vocabulary needs to be discoverable before callers trust a run.
+
+    **Why this matters:** claws and wrappers gate risky prompt execution on sandbox state. They need to know, from help or schema metadata, which fields exist (`active_namespace`, `filesystem_active`, `allowed_mounts`, `fallback_reason`), whether the command is local-only and credential-free, and how to interpret the aggregate `active` versus component-active fields. Today they must invoke sandbox, inspect an example response, and guess the semantics.
+
+    **Required fix shape:** (a) Extend `sandbox --help --output-format json` with structured fields: `usage:"claw sandbox [--output-format <format>]"`, `formats:["text","json"]`, `related:["/sandbox","claw status"]`, `local_only:true`, `requires_credentials:false`, `requires_provider_request:false`, `mutates_workspace:false`, `output_fields:["kind","active","supported","enabled","requested_namespace","active_namespace","requested_network","active_network","filesystem_active","filesystem_mode","allowed_mounts","fallback_reason","in_container","markers"]`, `component_fields:["namespace","network","filesystem"]`, `filesystem_modes:[...]`, and `schema_version`. (b) Add a machine-readable `active_semantics` field, e.g. `"all_requested_components_active"` or `"any_component_active"`, matching the eventual #448 fix. (c) Keep `message` as human summary only. (d) Derive the help schema from the same sandbox report struct/registry used to render the payload so added sandbox fields cannot drift from help. **Acceptance check:** `claw sandbox --help --output-format json | jq -e '.command=="sandbox" and .local_only==true and .requires_credentials==false and ([.output_fields[]] | index("filesystem_active") and index("allowed_mounts") and index("fallback_reason")) and (.active_semantics | type == "string")'` should pass; currently those structured fields are absent. Source: gaebal-gajae dogfood for the 2026-05-24 23:30 Clawhip nudge.


### PR DESCRIPTION
## ROADMAP pinpoint #688 — `sandbox --help --output-format json` lacks safety schema

Dogfooded for the 2026-05-24 23:30 Clawhip nudge (message 1508250775162196070). Reproduced on freshly rebuilt current `origin/main` binary (`git_sha f8e1bb726`). Active claw-code sessions: none.

### The pinpoint

`claw sandbox --help --output-format json` is JSON-valid on current main, but only message-level:

```bash
env -i HOME=/tmp/iso43/home PATH=/usr/bin:/bin TERM=dumb \
  claw sandbox --help --output-format json
```

Observed:

```json
{
  "command": "sandbox",
  "kind": "help",
  "message": "Sandbox\n  Usage            claw sandbox [--output-format <format>]\n  Purpose          inspect the resolved sandbox and isolation state for the current directory\n  Output           namespace, network, filesystem, and fallback details\n  Formats          text (default), json\n  Related          /sandbox · claw status",
  "topic": "sandbox"
}
```

Actual sandbox JSON on the same binary exposes the trust-state schema:

```bash
claw sandbox --output-format json | jq 'keys'
# active, active_namespace, active_network, allowed_mounts, enabled,
# fallback_reason, filesystem_active, filesystem_mode, in_container, kind,
# markers, requested_namespace, requested_network, supported
```

Help exposes none of this as structured metadata: no `output_fields`, `component_fields`, `mode_fields`, `active_semantics`, `local_only`, `requires_credentials:false`, `requires_provider_request:false`, or `mutates_workspace:false`.

### Why distinct

- #448 covers contradictory values and missing mount semantics in the actual sandbox payload.
- #688 covers help-schema discoverability for sandbox. Even if #448 fixes payload values, help still does not describe the sandbox field contract.
- #325 is broad top-level help prose-wrapper.
- #687 is status schema help.
- #686 is doctor check-schema help.

This one is sandbox-specific because sandbox is the safety/trust surface and its component-state vocabulary needs to be discoverable before callers trust a run.

### Why it matters

Claws and wrappers gate risky prompt execution on sandbox state. They need to know which fields exist (`active_namespace`, `filesystem_active`, `allowed_mounts`, `fallback_reason`), whether the command is local-only and credential-free, and how to interpret aggregate `active` versus component-active fields.

### Required fix shape

Extend `sandbox --help --output-format json` with structured fields:

```json
{
  "command": "sandbox",
  "kind": "help",
  "usage": "claw sandbox [--output-format <format>]",
  "formats": ["text", "json"],
  "related": ["/sandbox", "claw status"],
  "local_only": true,
  "requires_credentials": false,
  "requires_provider_request": false,
  "mutates_workspace": false,
  "output_fields": ["kind", "active", "supported", "enabled", "requested_namespace", "active_namespace", "requested_network", "active_network", "filesystem_active", "filesystem_mode", "allowed_mounts", "fallback_reason", "in_container", "markers"],
  "component_fields": ["namespace", "network", "filesystem"],
  "filesystem_modes": ["workspace-only"],
  "active_semantics": "all_requested_components_active",
  "schema_version": 1
}
```

Derive this from the same sandbox report struct/registry used to render the payload so added sandbox fields cannot drift from help.

### Acceptance check

```bash
claw sandbox --help --output-format json \
  | jq -e '.command=="sandbox" and .local_only==true and .requires_credentials==false and ([.output_fields[]] | index("filesystem_active") and index("allowed_mounts") and index("fallback_reason")) and (.active_semantics | type == "string")'
```

Currently those structured fields are absent.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
