### PR TITLE
Fix skills and agents JSON success status

### DIFF
--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -3627,6 +3627,7 @@ fn render_agents_report_json(cwd: &Path, agents: &[AgentSummary]) -> Value {
         "kind": "agents",
         "status": "ok",
         "action": "list",
+        "status": "ok",
         "working_directory": cwd.display().to_string(),
         "count": agents.len(),
         "summary": {
@@ -3710,6 +3711,7 @@ fn render_skills_report_json(skills: &[SkillSummary]) -> Value {
         "kind": "skills",
         "status": "ok",
         "action": "list",
+        "status": "ok",
         "summary": {
             "total": skills.len(),
             "active": active,
@@ -3744,6 +3746,7 @@ fn render_skill_install_report_json(skill: &InstalledSkill) -> Value {
     json!({
         "kind": "skills",
         "action": "install",
+        "status": "ok",
         "result": "installed",
         "invocation_name": &skill.invocation_name,
         "invoke_as": format!("${}", skill.invocation_name),
@@ -5312,6 +5315,7 @@ mod tests {
 
         assert_eq!(report["kind"], "agents");
         assert_eq!(report["action"], "list");
+        assert_eq!(report["status"], "ok");
         assert_eq!(report["working_directory"], workspace.display().to_string());
         assert_eq!(report["count"], 3);
         assert_eq!(report["summary"]["active"], 2);
@@ -5327,6 +5331,7 @@ mod tests {
         let help = handle_agents_slash_command_json(Some("help"), &workspace).expect("agents help");
         assert_eq!(help["kind"], "agents");
         assert_eq!(help["action"], "help");
+        assert_eq!(help["status"], "ok");
         assert_eq!(help["usage"]["direct_cli"], "claw agents [list|help]");
 
         // Unknown agents subcommands now return Err so CLI layer can exit 1.
@@ -5441,6 +5446,7 @@ mod tests {
         );
         assert_eq!(report["kind"], "skills");
         assert_eq!(report["action"], "list");
+        assert_eq!(report["status"], "ok");
         assert_eq!(report["summary"]["active"], 3);
         assert_eq!(report["summary"]["shadowed"], 1);
         assert_eq!(report["skills"][0]["name"], "plan");
@@ -5452,6 +5458,7 @@ mod tests {
         let help = handle_skills_slash_command_json(Some("help"), &workspace).expect("skills help");
         assert_eq!(help["kind"], "skills");
         assert_eq!(help["action"], "help");
+        assert_eq!(help["status"], "ok");
         assert_eq!(help["usage"]["aliases"][0], "/skill");
         assert_eq!(
             help["usage"]["direct_cli"],
@@ -5516,6 +5523,7 @@ mod tests {
         let sources = skills_help_json["usage"]["sources"]
             .as_array()
             .expect("skills help sources");
+        assert_eq!(skills_help_json["status"], "ok");
         assert_eq!(skills_help_json["usage"]["aliases"][0], "/skill");
         assert!(sources.iter().any(|value| value == ".omc/skills"));
         assert!(sources.iter().any(|value| value == ".agents/skills"));
@@ -5900,6 +5908,13 @@ mod tests {
         assert!(report.contains("Result           installed help"));
         assert!(report.contains("Invoke as        $help"));
         assert!(report.contains(&install_root.display().to_string()));
+
+        let json_report = super::render_skill_install_report_json(&installed);
+        assert_eq!(json_report["kind"], "skills");
+        assert_eq!(json_report["action"], "install");
+        assert_eq!(json_report["status"], "ok");
+        assert_eq!(json_report["invocation_name"], "help");
+        assert_eq!(json_report["invoke_as"], "$help");
 
         let roots = vec![SkillRoot {
             source: DefinitionSource::UserCodexHome,


### PR DESCRIPTION
## Summary
- add top-level `status: "ok"` to successful skills list/install JSON envelopes
- add top-level `status: "ok"` to successful agents list JSON envelopes
- add focused Rust assertions for skills/agents list/help/install JSON status contracts

## Verification
- `cargo fmt`
- `cargo test -p commands`
- `cargo build -p rusty-claude-cli --bin claw`
- rebuilt acceptance sweep: `for c in status mcp skills agents doctor sandbox init system-prompt version; do ./rust/target/debug/claw  --output-format json </dev/null | jq -e '.status | IN("ok","warn","error")'; done`

## Notes
- Error semantics unchanged.
- No unrelated LSP/MCP code touched.