### PR TITLE
Stabilize allowedTools rejection contract in CI

### DIFF
--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -11400,6 +11400,8 @@ mod tests {
 
     #[test]
     fn rejects_unknown_allowed_tools() {
+        let _env_guard = env_lock();
+        let _cwd_guard = cwd_guard();
         let error = parse_args(&["--allowedTools".to_string(), "teleport".to_string()])
             .expect_err("tool should be rejected");
         assert!(error.contains("unsupported tool in --allowedTools: teleport"));
@@ -11407,6 +11409,8 @@ mod tests {
 
     #[test]
     fn rejects_empty_allowed_tools_flag() {
+        let _env_guard = env_lock();
+        let _cwd_guard = cwd_guard();
         for raw in ["", ",,"] {
             let error = parse_args(&["--allowedTools".to_string(), raw.to_string()])
                 .expect_err("empty allowedTools should be rejected");


### PR DESCRIPTION
## Summary
- serialize the allowedTools rejection parser tests with the existing env/cwd guards
- keep the unsupported tool error contract unchanged
- avoid full-suite parallel cwd/env drift around parse_args

## Verification
- cargo test --verbose -p rusty-claude-cli --bin claw
- cargo test --verbose
- cargo check --workspace --locked
- cargo build --workspace --locked

Follow-up to the one-off PR #3103 build workflow failure; main post-merge CI was already green, this hardens the flaky parser test.