### PR TITLE
Fix ROADMAP #694: add local pre-push build gate

### DIFF
--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -8,6 +8,11 @@
 # caught before pushing to main or PR branches.
 set -euo pipefail
 
+if [[ "${SKIP_CLAW_PRE_PUSH_BUILD:-}" == "1" ]]; then
+  echo "pre-push: SKIP_CLAW_PRE_PUSH_BUILD=1 set; skipping cargo workspace build" >&2
+  exit 0
+fi
+
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
 cd "$repo_root"
 
@@ -16,5 +21,6 @@ if [[ ! -f rust/Cargo.toml ]]; then
   exit 0
 fi
 
-echo "pre-push: cargo build --manifest-path rust/Cargo.toml --workspace" >&2
-cargo build --manifest-path rust/Cargo.toml --workspace
+build_cmd=(cargo build --manifest-path rust/Cargo.toml --workspace --locked)
+echo "pre-push: ${build_cmd[*]}" >&2
+"${build_cmd[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,20 @@ cargo build --workspace
 .\target\debug\claw.exe --help
 ```
 
+## Local pre-push build gate
+
+Install the repository-local hook to catch stale compile errors before pushing:
+
+```bash
+git config core.hooksPath .github/hooks
+```
+
+This sets the repo's Git hook directory to `.github/hooks`; if you already use a
+custom `core.hooksPath`, copy or chain `.github/hooks/pre-push` instead. The hook
+runs `cargo build --manifest-path rust/Cargo.toml --workspace --locked` from the
+repository root. If you must bypass it for a non-code/docs-only push, set
+`SKIP_CLAW_PRE_PUSH_BUILD=1`; the hook prints when that escape hatch is used.
+
 ## Checks before opening a pull request
 
 Run the smallest relevant tests for your change, then the broader checks when

--- a/docs/g013-roadmap-pinpoints-693-695-verification-map.md
+++ b/docs/g013-roadmap-pinpoints-693-695-verification-map.md
@@ -17,7 +17,8 @@ covered by the Claw Code 2.0 board.
 
 - Hook: `.github/hooks/pre-push`
 - Install command: `git config core.hooksPath .github/hooks`
-- Gate: `cargo build --manifest-path rust/Cargo.toml --workspace`
+- Gate: `cargo build --manifest-path rust/Cargo.toml --workspace --locked`
+- Escape hatch: `SKIP_CLAW_PRE_PUSH_BUILD=1` prints an explicit skip message.
 - Purpose: mirror the CI build job locally so stale field/variant references are
   caught before push.
 
@@ -43,5 +44,5 @@ bash -n .github/hooks/pre-push
 cargo fmt --manifest-path rust/Cargo.toml --all -- --check
 cargo test --manifest-path rust/Cargo.toml -p claw-analog rag_response_ -- --nocapture
 cargo test --manifest-path rust/Cargo.toml -p runtime startup_preflight -- --nocapture
-cargo build --manifest-path rust/Cargo.toml --workspace
+cargo build --manifest-path rust/Cargo.toml --workspace --locked
 ```


### PR DESCRIPTION
## Summary
- add/tighten `.github/hooks/pre-push` as a repository-local pre-push safety gate
- run `cargo build --manifest-path rust/Cargo.toml --workspace --locked` from repo root
- document install, existing `core.hooksPath` handling, and explicit `SKIP_CLAW_PRE_PUSH_BUILD=1` bypass

## Verification
- `bash -n .github/hooks/pre-push`
- `SKIP_CLAW_PRE_PUSH_BUILD=1 .github/hooks/pre-push`
- `.github/hooks/pre-push`
- `git diff --check`
- `python3 .github/scripts/check_doc_source_of_truth.py`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`

Not run: `shellcheck` / `markdownlint` (not installed in this environment).
