### PR TITLE
Keep local pre-push gate output machine-clean

### DIFF
--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -13,7 +13,7 @@ cd "$repo_root"
 
 if [[ -x scripts/roadmap-check-ids.sh ]]; then
   echo "pre-push: scripts/roadmap-check-ids.sh" >&2
-  scripts/roadmap-check-ids.sh
+  scripts/roadmap-check-ids.sh >&2
 fi
 
 if [[ "${SKIP_CLAW_PRE_PUSH_BUILD:-}" == "1" ]]; then


### PR DESCRIPTION
## Summary
- Keep the local pre-push hook's roadmap ID pre-check output on stderr
- Preserve stdout for machine callers while retaining the ROADMAP #694 cargo workspace build gate
- Validates the already-present ROADMAP #693 typed analog phase errors and #695 startup preflight coverage

## Validation
- `python3 -m pytest tests/test_pre_push_hook_contract.py -q`
- `cargo test --manifest-path rust/Cargo.toml -p claw-analog rag_response -- --nocapture`
- `cargo test --manifest-path rust/Cargo.toml -p runtime startup_preflight -- --nocapture`
- `python3 scripts/validate_cc2_board.py --board .omx/cc2/board.json`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo build --manifest-path rust/Cargo.toml --workspace --locked`

## Final gate
- AI-slop-cleaner scoped to `.github/hooks/pre-push`: no-op/pass; explicit skip escape hatch is tested and non-masking
- Code review: approve; architecture clear for one-line stderr routing fix
