### PR TITLE
docs(usage): list qwen-max/qwen-plus in the model alias table

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -349,6 +349,8 @@ These are the models registered in the built-in alias table with known token lim
 | `grok-mini` / `grok-3-mini` | `grok-3-mini` | xAI | 64 000 | 131 072 |
 | `grok-2` | `grok-2` | xAI | — | — |
 | `kimi` | `kimi-k2.5` | DashScope | 16 384 | 256 000 |
+| `qwen-max` | `qwen-max` | DashScope | 8 192 | 131 072 |
+| `qwen-plus` | `qwen-plus` | DashScope | 8 192 | 131 072 |
 | `gpt-4.1` / `gpt-4.1-mini` / `gpt-4.1-nano` | same | OpenAI-compatible | 32 768 | 1 047 576 |
 | `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.4-nano` | same | OpenAI-compatible | 128 000 | 1 000 000 / 400 000 |
 


### PR DESCRIPTION
## Summary

The "Tested models and aliases" table in `USAGE.md` omitted the `qwen-max` and `qwen-plus` DashScope models, even though:

- both have first-class token limits in `rust/crates/api/src/providers/mod.rs` (`model_token_limit`: 8192 max output / 131072 context), and
- both are already documented as working aliases in the **Alibaba DashScope (Qwen)** section of the same guide.

This adds their rows so the alias table matches the code and the rest of `USAGE.md`. Rows are placed next to `kimi` to keep the DashScope models grouped, and use the same space-separated number style as the existing rows.

## Changes

- `USAGE.md`: add `qwen-max` and `qwen-plus` rows to the model alias table.

## Verification

- Docs-only change; no code or behavior touched.
- Token limits cross-checked against `model_token_limit` in `crates/api/src/providers/mod.rs`.
- `.github/scripts/check_doc_source_of_truth.py` only forbids stale links/assets — this change introduces none.

## Test plan

- [x] Visual diff review of the rendered table
- [x] Values match `model_token_limit` in the api crate