### PR TITLE
fix: add roadmap next-id help handling

### DIFF
--- a/scripts/roadmap-next-id.sh
+++ b/scripts/roadmap-next-id.sh
@@ -17,7 +17,25 @@
 # and resolve any append collision at git-push time.
 set -euo pipefail
 
-ROADMAP="${1:-ROADMAP.md}"
+ROADMAP="ROADMAP.md"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      sed -n '2,15p' "$0" | sed 's/^# //; s/^#//'
+      exit 0
+      ;;
+    --*)
+      echo "error: unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      ROADMAP="$1"
+      shift
+      ;;
+  esac
+done
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 CHECKER="$SCRIPT_DIR/roadmap-check-ids.sh"
 


### PR DESCRIPTION
## Summary
- make `scripts/roadmap-next-id.sh --help` and `-h` print usage instead of treating the flag as a ROADMAP path
- fail unknown options explicitly with exit 2
- keep positional ROADMAP path behavior unchanged

## Validation
- `scripts/roadmap-next-id.sh --help`
- `scripts/roadmap-next-id.sh -h`
- `scripts/roadmap-next-id.sh bogus`
- `scripts/roadmap-next-id.sh --bogus`
- `scripts/roadmap-next-id.sh`
- `scripts/roadmap-check-ids.sh`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*