### PR TITLE
fix: reject extra roadmap helper paths

### DIFF
--- a/scripts/roadmap-check-ids.sh
+++ b/scripts/roadmap-check-ids.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 MIN_ID=723
 ROADMAP="ROADMAP.md"
+ROADMAP_PATH_SEEN=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -31,7 +32,12 @@ while [[ $# -gt 0 ]]; do
       exit 2
       ;;
     *)
+      if [[ "$ROADMAP_PATH_SEEN" -ne 0 ]]; then
+        echo "error: unexpected extra ROADMAP path: $1" >&2
+        exit 2
+      fi
       ROADMAP="$1"
+      ROADMAP_PATH_SEEN=1
       shift
       ;;
   esac

--- a/scripts/roadmap-next-id.sh
+++ b/scripts/roadmap-next-id.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 ROADMAP="ROADMAP.md"
+ROADMAP_PATH_SEEN=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -30,7 +31,12 @@ while [[ $# -gt 0 ]]; do
       exit 2
       ;;
     *)
+      if [[ "$ROADMAP_PATH_SEEN" -ne 0 ]]; then
+        echo "error: unexpected extra ROADMAP path: $1" >&2
+        exit 2
+      fi
       ROADMAP="$1"
+      ROADMAP_PATH_SEEN=1
       shift
       ;;
   esac


### PR DESCRIPTION
## Summary
- make ROADMAP helper scripts reject multiple positional ROADMAP paths instead of silently using the last one
- preserve default and single-path behavior
- keep help/unknown option behavior intact

## Validation
- `scripts/roadmap-check-ids.sh`
- `scripts/roadmap-next-id.sh`
- `scripts/roadmap-check-ids.sh /tmp/ROADMAP.good.md`
- `scripts/roadmap-check-ids.sh /tmp/ROADMAP.good.md /tmp/ROADMAP.dup811.md`
- `scripts/roadmap-next-id.sh /tmp/ROADMAP.good.md /tmp/ROADMAP.dup811.md`
- `scripts/roadmap-check-ids.sh /tmp/ROADMAP.dup811.md`
- `scripts/roadmap-next-id.sh --help`
- `scripts/roadmap-check-ids.sh --help`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*