### PR TITLE
fix: make cc2 generator missing source error concise

### DIFF
--- a/scripts/generate_cc2_board.py
+++ b/scripts/generate_cc2_board.py
@@ -504,7 +504,11 @@ def main() -> int:
     repo_root = args.repo_root.resolve()
     out_dir = args.out_dir or (repo_root / ".omx" / "cc2")
     out_dir.mkdir(parents=True, exist_ok=True)
-    board = build_board(repo_root)
+    try:
+        board = build_board(repo_root)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     board_json = out_dir / "board.json"
     board_md = out_dir / "board.md"
     board_json.write_text(json.dumps(board, indent=2, sort_keys=True) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- replace traceback when `generate_cc2_board.py` cannot locate source `.omx` with a concise `error:` message
- keep successful generation/validation paths unchanged

## Validation
- `python3 scripts/generate_cc2_board.py --repo-root /tmp/claw-cc2-nosource`
- `python3 scripts/generate_cc2_board.py --help`
- `python3 scripts/validate_cc2_board.py`
- `python3 scripts/cc2_board.py validate`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*