### PR TITLE
fix: make cc2 validator board read errors concise

### DIFF
--- a/scripts/validate_cc2_board.py
+++ b/scripts/validate_cc2_board.py
@@ -44,7 +44,14 @@ def main() -> int:
     args = parser.parse_args()
     repo_root = args.repo_root.resolve()
     board_path = args.board or (repo_root / ".omx" / "cc2" / "board.json")
-    board = json.loads(board_path.read_text(encoding="utf-8"))
+    try:
+        board = json.loads(board_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"error: board not found at {board_path}")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"error: invalid board JSON at {board_path}: {exc}")
+        return 1
     errors: list[str] = []
     ids = set()
     for index, item in enumerate(board.get("items", []), 1):


### PR DESCRIPTION
## Summary
- replace traceback when `validate_cc2_board.py` cannot read board JSON with concise `error:` messages
- also report malformed board JSON without a Python traceback
- keep successful validation path unchanged

## Validation
- `python3 scripts/validate_cc2_board.py --repo-root /tmp/claw-cc2-nosource`
- `python3 scripts/validate_cc2_board.py --repo-root /tmp/claw-cc2-badjson`
- `python3 scripts/validate_cc2_board.py`
- `python3 scripts/validate_cc2_board.py --help`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*