### PR TITLE
fix: resolve cc2 wrapper tools from script root

### DIFF
--- a/scripts/cc2_board.py
+++ b/scripts/cc2_board.py
@@ -26,11 +26,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     repo_root = args.repo_root.resolve()
+    script_root = Path(__file__).resolve().parent
+    tool_root = script_root.parent
     board_json = repo_root / args.board_json
     board_md = repo_root / args.board_md
-    generator = repo_root / "scripts" / "generate_cc2_board.py"
-    validator = repo_root / "scripts" / "validate_cc2_board.py"
-    renderer = repo_root / ".omx" / "cc2" / "render_board_md.py"
+    generator = script_root / "generate_cc2_board.py"
+    validator = script_root / "validate_cc2_board.py"
+    renderer = tool_root / ".omx" / "cc2" / "render_board_md.py"
 
     if args.command == "generate":
         rc = run([sys.executable, str(generator), "--repo-root", str(repo_root), "--out-dir", str(board_json.parent)], repo_root)


### PR DESCRIPTION
## Summary
- make `scripts/cc2_board.py` resolve generator/validator/renderer from the wrapper script location, not from `--repo-root`
- keeps external `--repo-root` validation/generation from failing with Python `can't open file <repo>/scripts/...`
- preserves existing default repo behavior

## Validation
- `python3 scripts/cc2_board.py generate --repo-root /tmp/claw-cc2-nosource`
- `python3 scripts/cc2_board.py validate --repo-root /tmp/claw-cc2-nosource`
- `python3 scripts/cc2_board.py validate --repo-root /tmp/claw-cc2-empty`
- `python3 scripts/cc2_board.py validate`
- `python3 scripts/cc2_board.py --help`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*