### PR TITLE
fix: avoid cc2 generator dirs on missing source

### DIFF
--- a/scripts/generate_cc2_board.py
+++ b/scripts/generate_cc2_board.py
@@ -503,12 +503,12 @@ def main() -> int:
     args = parser.parse_args()
     repo_root = args.repo_root.resolve()
     out_dir = args.out_dir or (repo_root / ".omx" / "cc2")
-    out_dir.mkdir(parents=True, exist_ok=True)
     try:
         board = build_board(repo_root)
     except FileNotFoundError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+    out_dir.mkdir(parents=True, exist_ok=True)
     board_json = out_dir / "board.json"
     board_md = out_dir / "board.md"
     board_json.write_text(json.dumps(board, indent=2, sort_keys=True) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- avoid creating `.omx/cc2` output directories when CC2 generator fails before locating source `.omx`
- keep successful generation code path unchanged; only moves output directory creation after source board build succeeds

## Validation
- `python3 scripts/generate_cc2_board.py --repo-root /tmp/cc2-nosource-sideeffect`
- `test ! -e /tmp/cc2-nosource-sideeffect/.omx`
- `python3 scripts/generate_cc2_board.py --help`
- `python3 scripts/validate_cc2_board.py`
- `python3 scripts/cc2_board.py validate`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*