### PR TITLE
fix: make cc2 validator directory board error concise

### DIFF
--- a/scripts/validate_cc2_board.py
+++ b/scripts/validate_cc2_board.py
@@ -49,6 +49,9 @@ def main() -> int:
     except FileNotFoundError:
         print(f"error: board not found at {board_path}")
         return 1
+    except IsADirectoryError:
+        print(f"error: board path is a directory: {board_path}")
+        return 1
     except json.JSONDecodeError as exc:
         print(f"error: invalid board JSON at {board_path}: {exc}")
         return 1


### PR DESCRIPTION
## Summary
- handle `--board` pointing at a directory with a concise error instead of an `IsADirectoryError` traceback
- wrapper validation inherits the concise message
- preserve missing/invalid/success paths

## Validation
- `python3 scripts/validate_cc2_board.py --board /tmp/cc2-dir-board`
- `python3 scripts/cc2_board.py validate --board-json /tmp/cc2-dir-board --board-md /tmp/cc2-dir-board`
- `python3 scripts/validate_cc2_board.py --board /tmp/cc2-badjson/board.json`
- `python3 scripts/validate_cc2_board.py`
- `python3 scripts/cc2_board.py validate`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*