### PR TITLE
fix: add dogfood build help handling

### DIFF
--- a/scripts/dogfood-build.sh
+++ b/scripts/dogfood-build.sh
@@ -13,6 +13,24 @@
 #
 set -euo pipefail
 
+usage() {
+    sed -n '2,12p' "$0" | sed 's/^# //; s/^#//'
+}
+
+if [[ $# -gt 0 ]]; then
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+fi
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUST_DIR="$REPO_ROOT/rust"
 BINARY="$RUST_DIR/target/debug/claw"


### PR DESCRIPTION
## Summary
- make `scripts/dogfood-build.sh --help` / `-h` print usage instead of building
- reject unknown arguments with exit 2 and usage
- keep normal build/provenance behavior unchanged

## Validation
- `bash scripts/dogfood-build.sh --help`
- `bash scripts/dogfood-build.sh --bogus`
- `timeout 25s bash scripts/dogfood-build.sh`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*