### PR TITLE
docs: use trap cleanup in dogfood build guidance

### DIFF
--- a/scripts/dogfood-build.sh
+++ b/scripts/dogfood-build.sh
@@ -78,8 +78,8 @@ echo "  export CLAW=$BINARY" >&2
 echo "" >&2
 echo "  Dogfood with isolated config (no real user config on stderr):" >&2
 echo "    CLAW_ISOLATED=\$(mktemp -d)" >&2
+echo "    trap 'rm -rf "\$CLAW_ISOLATED"' EXIT" >&2
 echo "    CLAW_CONFIG_HOME=\$CLAW_ISOLATED \$CLAW plugins list --output-format json" >&2
-echo "    rm -rf \$CLAW_ISOLATED" >&2
 echo "" >&2
 echo "  cargo run overhead: ~1s/invocation vs 7ms for pre-built binary." >&2
 echo "  Prefer pre-built binary (\$CLAW) for dogfood loops." >&2


### PR DESCRIPTION
## Summary
- update `scripts/dogfood-build.sh` emitted isolated-config example to use `trap` cleanup
- avoids leaving temp config directories behind when a dogfood command fails or is interrupted
- keeps build/provenance behavior unchanged

## Validation
- `bash scripts/dogfood-build.sh --help`
- `timeout 25s bash scripts/dogfood-build.sh`
- `CLAW_CONFIG_HOME=$iso "$CLAW" plugins list --output-format json`
- `python3 -m json.tool /tmp/db-plugin.json`

—
*[repo owner's gaebal-gajae (clawbot) 🦞]*