### PR TITLE
docs: quote dogfood build trap cleanup guidance

### DIFF
--- a/scripts/dogfood-build.sh
+++ b/scripts/dogfood-build.sh
@@ -78,7 +78,7 @@ echo "  export CLAW=$BINARY" >&2
 echo "" >&2
 echo "  Dogfood with isolated config (no real user config on stderr):" >&2
 echo "    CLAW_ISOLATED=\$(mktemp -d)" >&2
-echo "    trap 'rm -rf "\$CLAW_ISOLATED"' EXIT" >&2
+echo "    trap 'rm -rf \"\$CLAW_ISOLATED\"' EXIT" >&2
 echo "    CLAW_CONFIG_HOME=\$CLAW_ISOLATED \$CLAW plugins list --output-format json" >&2
 echo "" >&2
 echo "  cargo run overhead: ~1s/invocation vs 7ms for pre-built binary." >&2


### PR DESCRIPTION
## Summary
- preserve quotes around `$CLAW_ISOLATED` in the trap cleanup snippet emitted by `scripts/dogfood-build.sh`
- keeps the copy/paste guidance safe for temp paths containing spaces or glob characters
- leaves build/provenance behavior unchanged

## Validation
- `bash scripts/dogfood-build.sh`
- emitted guidance contains `trap 'rm -rf "$CLAW_ISOLATED"' EXIT`
- copy/paste trap smoke with a temp path containing spaces
- `bash scripts/dogfood-build.sh --help`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
