### PR TITLE
Test doctor help JSON flag order

### DIFF
--- a/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
+++ b/rust/crates/rusty-claude-cli/tests/output_format_contract.rs
@@ -72,6 +72,18 @@ fn doctor_help_json_is_local_structured_and_bounded_702() {
     fs::create_dir_all(&root).expect("temp dir should exist");
 
     let parsed = assert_json_command(&root, &["--output-format", "json", "doctor", "--help"]);
+    assert_doctor_help_json_contract(&parsed);
+
+    let suffix_parsed =
+        assert_json_command(&root, &["doctor", "--help", "--output-format", "json"]);
+    assert_doctor_help_json_contract(&suffix_parsed);
+
+    let help_topic_parsed =
+        assert_json_command(&root, &["help", "doctor", "--output-format", "json"]);
+    assert_doctor_help_json_contract(&help_topic_parsed);
+}
+
+fn assert_doctor_help_json_contract(parsed: &Value) {
     assert_eq!(parsed["kind"], "help");
     assert_eq!(parsed["action"], "help");
     assert_eq!(parsed["status"], "ok");


### PR DESCRIPTION
## Summary
- extends the doctor help JSON regression to cover suffix flag order (`doctor --help --output-format json`)
- covers topic-help routing (`help doctor --output-format json`) with the same structured local-only contract
- keeps this as a regression-only follow-up after #3184 so the fast path stays machine-discoverable across common flag orders

## Validation
- `cargo test --manifest-path rust/Cargo.toml -p rusty-claude-cli --test output_format_contract doctor_help_json -- --nocapture`
- `cargo build -q --bin claw`
- `./target/debug/claw --output-format json doctor --help`
- `./target/debug/claw doctor --help --output-format json`
- `./target/debug/claw help doctor --output-format json`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
