### PR TITLE
docs: add provider referral links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,15 @@ Claw Code is built in the open alongside the broader UltraWorkers toolchain:
 - [oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex)
 - [UltraWorkers Discord](https://discord.gg/5TUQKqFWd)
 
+## Providers
+
+Claw Code supports the following API providers:
+
+- [Anthropic (Claude)](https://console.anthropic.com/)
+- [OpenAI](https://platform.openai.com/)
+- [xAI (Grok)](https://console.x.ai/)
+- [DashScope (Qwen/Kimi)](https://dashscope.console.aliyun.com/)
+
 ## Ownership / affiliation disclaimer
 
 - This repository does **not** claim ownership of the original Claude Code source material.


### PR DESCRIPTION
## Problem

The README does not list the supported API providers or link to their consoles. New users have to hunt through USAGE.md or source code to figure out where to obtain API keys for each provider.

## Solution

Add a minimal "Providers" section to README.md with one line per supported provider linking to its console/dashboard:
- Anthropic (Claude)
- OpenAI
- xAI (Grok)
- DashScope (Qwen/Kimi)

This is a standalone docs-only change. Similar referral links were previously included in PR #2983 but were flagged as "unrelated promotional content" because they were bundled with a PR_DESCRIPTION.md in a fix PR. In a dedicated docs PR, these links serve a practical onboarding purpose.

## Changes

- `README.md` — added 9 lines: a "Providers" section with 4 provider links, placed between "Ecosystem" and "Ownership / affiliation disclaimer"

## Diff verification

```
README.md | 9 +++++++++
1 file changed, 9 insertions(+)
```

No upstream reverts, no deletions, no code changes.

## Testing

1. Open the README and verify the "Providers" section appears between "Ecosystem" and "Ownership / affiliation disclaimer"
2. Click each provider link and confirm it resolves to the correct console page
3. Run `cargo check --workspace` and `cargo test` — no code was changed so these should be unaffected
