### PR TITLE
fix: validate attached redirection paths

### DIFF
--- a/src/path_scope.py
+++ b/src/path_scope.py
@@ -11,6 +11,7 @@ _GLOB_META = set('*?[')
 _WINDOWS_DRIVE_RE = re.compile(r'^[A-Za-z]:[\\/]')
 _WINDOWS_UNC_RE = re.compile(r'^(?:\\\\|//)[^\\/]+[\\/][^\\/]+')
 _ENV_ASSIGNMENT_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*=')
+_REDIRECTION_TARGET_RE = re.compile(r'^(?:\d*)?(?:<>|>>?|<)(.+)$|^&>>?(.+)$')
 
 
 @dataclass(frozen=True)
@@ -118,6 +119,7 @@ def extract_path_candidates(payload: str) -> tuple[str, ...]:
     for token in (*tokens, *raw_tokens):
         if not token or token.startswith('-') or _ENV_ASSIGNMENT_RE.match(token):
             continue
+        token = _strip_redirection_operator(token)
         expanded = os.path.expandvars(os.path.expanduser(token))
         if _looks_like_path(token) or _looks_like_path(expanded):
             candidate = expanded if _looks_like_path(expanded) else token
@@ -136,6 +138,13 @@ def _looks_like_path(token: str) -> bool:
         or any(char in token for char in _GLOB_META)
         or _is_windows_absolute(token)
     )
+
+
+def _strip_redirection_operator(token: str) -> str:
+    match = _REDIRECTION_TARGET_RE.match(token)
+    if match is None:
+        return token
+    return next(group for group in match.groups() if group is not None)
 
 
 def _is_windows_absolute(value: str) -> bool:

--- a/tests/test_security_scope.py
+++ b/tests/test_security_scope.py
@@ -72,6 +72,28 @@ class WorkspacePathScopeTests(unittest.TestCase):
             self.assertFalse(decision.allowed)
             self.assertIn(str(outside.resolve()), decision.resolved or '')
 
+    def test_attached_shell_redirection_targets_are_validated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workspace = root / 'workspace'
+            outside = root / 'outside'
+            workspace.mkdir()
+            outside.mkdir()
+            (outside / 'secret.txt').write_text('secret')
+
+            self.assertEqual(
+                ('../outside/secret.txt', '../outside/error.log'),
+                extract_path_candidates(
+                    'cat <../outside/secret.txt 2>../outside/error.log'
+                ),
+            )
+            decision = WorkspacePathScope.from_root(workspace).validate_payload(
+                'cat <../outside/secret.txt 2>../outside/error.log'
+            )
+
+            self.assertFalse(decision.allowed)
+            self.assertIn(str(outside.resolve()), decision.resolved or '')
+
     def test_explicit_worktree_roots_are_allowed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- strip attached shell redirection operators before extracting path candidates
- validate redirection targets like <../file and 2>../file against workspace scope
- add regression coverage for attached redirection targets

## Validation
- python3 -m unittest tests.test_security_scope -q
- python3 -m compileall -q src/path_scope.py tests/test_security_scope.py
- git diff --check -- src/path_scope.py tests/test_security_scope.py