### PR TITLE
Add route.bible skill

### DIFF
--- a/skills/route.bible/skill.md
+++ b/skills/route.bible/skill.md
@@ -1,0 +1,14 @@
+# route.bible/skill.md
+
+## Overview
+route.bible is a routing and deep-linking layer for Bible passages. This skill allows the agent to generate and resolve app-agnostic Bible links.
+
+## stable URL contract
+- `https://route.bible/{reference}` (e.g., `https://route.bible/John.3.16`)
+- Supported formats: OSIS identifiers, common abbreviations.
+
+## Local Parsing
+Use `grab-bcv` for local parsing of references before routing.
+
+## Integration
+To integrate, refer to the hosted documentation at `https://route.bible/docs`.

--- a/skills/route.bible/skill.md
+++ b/skills/route.bible/skill.md
@@ -1,14 +1,40 @@
-# route.bible/skill.md
+---
+name: route-bible
+description: "Reference Bible passages via app-agnostic links and QR codes."
+version: 1.0.0
+author: Dylan Shade (dpshde)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Bible, Religion, Scripture, Routing, API]
+---
 
-## Overview
-route.bible is a routing and deep-linking layer for Bible passages. This skill allows the agent to generate and resolve app-agnostic Bible links.
+# route.bible
 
-## stable URL contract
-- `https://route.bible/{reference}` (e.g., `https://route.bible/John.3.16`)
-- Supported formats: OSIS identifiers, common abbreviations.
+Reference Bible passages and generate app-agnostic links or QR codes. route.bible acts as a universal router, allowing users to open scriptures in their preferred Bible application (YouVersion, BibleGateway, Logos, etc.).
 
-## Local Parsing
-Use `grab-bcv` for local parsing of references before routing.
+## Quick Reference
 
-## Integration
-To integrate, refer to the hosted documentation at `https://route.bible/docs`.
+| Action | Pattern |
+|--------|---------|
+| Generate link | `https://route.bible/GEN.1.1` |
+| Generate QR code | `https://route.bible/GEN.1.1?qr=true` |
+
+## Usage
+
+The routing layer follows a stable URL contract using standard book abbreviations and OSIS-style references.
+
+### Canonical Link Generation
+
+To generate a universal link for a passage, use the following URL pattern:
+`https://route.bible/<BOOK>.<CHAPTER>.<VERSE>`
+
+Examples:
+- `https://route.bible/GEN.1.1`
+- `https://route.bible/JHN.3.16`
+
+### QR Code Integration
+
+To generate a QR code pointing to a passage, append `?qr=true` to the canonical link.
+- `https://route.bible/ROM.12.1-2?qr=true`


### PR DESCRIPTION
This PR adds the skill definition for route.bible, enabling the agent to handle app-agnostic Bible passage routing.