### PR TITLE
Allow null device redirection in path scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,13 @@ Out of scope:
 - reports against third-party providers or upstream tools without a Claw Code
   integration issue.
 
+## Workspace path scope
+
+Claw Code validates shell and file-tool path operands against the active
+workspace roots. Redirection to `/dev/null` is treated as a null-device sink,
+not as a filesystem read or write target, so it is allowed even though it is
+outside the workspace tree.
+
 ## Handling expectations
 
 Maintainers will acknowledge valid private reports as soon as practical, keep

--- a/src/path_scope.py
+++ b/src/path_scope.py
@@ -59,6 +59,8 @@ class WorkspacePathScope:
 
     def validate_path(self, candidate: str | Path, cwd: str | Path | None = None) -> PathScopeDecision:
         raw = os.path.expandvars(os.path.expanduser(str(candidate)))
+        if raw == os.devnull:
+            return PathScopeDecision(True, 'null device is outside filesystem scope', str(candidate), raw)
         if _is_windows_absolute(raw):
             return self._validate_windows_path(raw)
         base = Path(cwd).expanduser().resolve(strict=False) if cwd else self.roots[0]

--- a/tests/test_security_scope.py
+++ b/tests/test_security_scope.py
@@ -94,6 +94,15 @@ class WorkspacePathScopeTests(unittest.TestCase):
             self.assertFalse(decision.allowed)
             self.assertIn(str(outside.resolve()), decision.resolved or '')
 
+    def test_null_device_redirection_is_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / 'workspace'
+            workspace.mkdir()
+
+            decision = WorkspacePathScope.from_root(workspace).validate_payload('echo ok >/dev/null')
+
+            self.assertTrue(decision.allowed, decision.reason)
+
     def test_explicit_worktree_roots_are_allowed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- allow WorkspacePathScope to treat /dev/null as a null-device sink instead of an out-of-workspace path
- add coverage for echo ok >/dev/null

## Validation
- python3 -m unittest tests.test_security_scope
- python3 -m unittest discover tests