### PR TITLE
Improve command lookup normalization

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -55,7 +55,8 @@ def command_names() -> list[str]:
 
 
 def get_command(name: str) -> PortingModule | None:
-    needle = COMMAND_ALIASES.get(name.lower(), name.lower())
+    normalized = name.strip().lower()
+    needle = COMMAND_ALIASES.get(normalized, normalized)
     for module in PORTED_COMMANDS:
         if module.name.lower() == needle:
             return module
@@ -72,8 +73,15 @@ def get_commands(cwd: str | None = None, include_plugin_commands: bool = True, i
 
 
 def find_commands(query: str, limit: int = 20) -> list[PortingModule]:
-    needle = query.lower()
+    needle = query.strip().lower()
     matches = [module for module in PORTED_COMMANDS if needle in module.name.lower() or needle in module.source_hint.lower()]
+    matches.sort(
+        key=lambda module: (
+            module.name.lower() != needle,
+            not module.name.lower().startswith(needle),
+            needle not in module.name.lower(),
+        )
+    )
     return matches[:limit]
 
 

--- a/tests/test_porting_workspace.py
+++ b/tests/test_porting_workspace.py
@@ -183,6 +183,13 @@ class PortingWorkspaceTests(unittest.TestCase):
                 self.assertIn("Mirrored command 'plugin'", result.stdout)
                 self.assertNotIn('Unknown mirrored command', result.stdout)
 
+    def test_command_lookup_normalizes_user_input_whitespace(self) -> None:
+        from src.commands import execute_command, find_commands, get_command
+
+        self.assertEqual('plugin', get_command('  PLUGINS  ').name)
+        self.assertEqual('review', find_commands('  review  ', limit=1)[0].name)
+        self.assertIn("Mirrored command 'plugin'", execute_command('  marketplace  ', 'browse').message)
+
     def test_route_plugin_slash_commands_match_commands(self) -> None:
         prompts = ('/plugin list', '/plugins list', '/marketplace browse', '/reload-plugins')
         for prompt in prompts:


### PR DESCRIPTION
## Summary
- Trim and normalize command lookup input before alias resolution.
- Prioritize exact command-name matches before broader substring matches.
- Add coverage for whitespace/case-normalized command lookup and execution.

## Validation
- env PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_porting_workspace.PortingWorkspaceTests.test_commands_and_tools_cli_run tests.test_porting_workspace.PortingWorkspaceTests.test_command_lookup_normalizes_user_input_whitespace
- git diff --check