### PR TITLE
docs: correct rust workspace crate count to 11

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -221,7 +221,7 @@ rust/
 ## Stats
 
 - **~20K lines** of Rust
-- **9 crates** in workspace
+- **11 crates** in workspace
 - **Binary name:** `claw`
 - **Default model:** `claude-opus-4-7`
 - **Default permissions:** `workspace-write`


### PR DESCRIPTION
## Summary

Follow-up doc fix after #3268.

The Stats section of `rust/README.md` states **9 crates** in the workspace, but the workspace (`members = ["crates/*"]`) now contains **11** crates:

`api`, `claw-analog`, `claw-rag-service`, `commands`, `compat-harness`, `mock-anthropic-service`, `plugins`, `runtime`, `rusty-claude-cli`, `telemetry`, `tools`

(verified by counting `rust/crates/*/Cargo.toml` — 11 manifests). This PR updates only that number; it does not restructure the layout or responsibilities sections.

## Note on a second candidate fix (not included)

While investigating I also checked the reported broken link in `how_to_run.md` (`[futute.md](futute.md)`). I did **not** change it: neither `futute.md` nor a correctly-spelled `future.md` exists anywhere in the repository, so retargeting the link would not resolve to a real file. Left untouched pending a decision on whether that target doc should be created.