### PR TITLE
fix(cli): stop reprinting streamed assistant text after 'Done' in non-compact text mode

### DIFF
--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -7908,6 +7908,9 @@ impl LiveCli {
                         match new_runtime.run_turn(input, Some(&mut rp)) {
                             Ok(summary) => {
                                 self.replace_runtime(new_runtime)?;
+                                if !final_assistant_text(&summary).is_empty() {
+                                    println!();
+                                }
                                 spinner.finish(
                                     if round == 0 {
                                         "✨ Done (after auto-compact)"

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -7763,15 +7763,20 @@ impl LiveCli {
         match result {
             Ok(summary) => {
                 self.replace_runtime(runtime)?;
+                // The assistant response was already streamed to the terminal live
+                // during the turn (emit_output = true), so reprinting the full text
+                // here would duplicate the entire message. When text was streamed,
+                // emit a newline first so `spinner.finish`'s line-clear lands on a
+                // fresh line instead of erasing the last streamed line.
+                let final_text = final_assistant_text(&summary);
+                if !final_text.is_empty() {
+                    println!();
+                }
                 spinner.finish(
                     "✨ Done",
                     TerminalRenderer::new().color_theme(),
                     &mut stdout,
                 )?;
-                let final_text = final_assistant_text(&summary);
-                if !final_text.is_empty() {
-                    println!("{final_text}");
-                }
                 println!();
                 if let Some(event) = summary.auto_compaction {
                     println!(


### PR DESCRIPTION
## Summary

Fixes #3258.

In **non-compact text mode** (and the interactive REPL), `LiveCli::run_turn`
prints the entire assistant response **twice**:

1. It runs the turn with `emit_output = true`, so `AnthropicRuntimeClient::consume_stream`
   already streams and renders every text delta to the terminal live
   (`main.rs`, `ContentBlockDelta::TextDelta` / `MessageStop`).
2. After `spinner.finish("✨ Done")` it then calls
   `println!("{final_text}")`, reprinting the whole message that was just streamed.

The reprint was originally added because `Spinner::finish` runs
`MoveToColumn(0)` + `Clear(ClearType::CurrentLine)` and would otherwise erase
the last streamed line (the streamed tail has no trailing newline). Reprinting
the full text "fixed" the erased line but duplicated everything above it.

## Fix

Protect only the last streamed line instead of reprinting the whole message:

- When there is streamed assistant text, emit a single `println!()` **before**
  `spinner.finish` so the line-clear lands on a fresh empty line rather than the
  last content line.
- Remove the `println!("{final_text}")` reprint.

`final_text` is still computed and used to decide whether a newline is needed,
so the empty-response path (tool-only turns) is unchanged. Compact/JSON paths
use `emit_output = false` and print the message exactly once — they are
untouched.

## Scope

- 1 file, `rust/crates/rusty-claude-cli/src/main.rs` (`LiveCli::run_turn`), +9 -4.
- No signature/API changes; no test depended on the duplicate output.

## Verification

Verified by reading and tracing the streaming path (`consume_stream` writes each
text delta live when `emit_output` is true; `prepare_turn_runtime(true)` is used
by `run_turn`, while the compact/JSON paths use `prepare_turn_runtime(false)`)
and by inspecting `Spinner::finish`'s line-clear behavior. **Not compiled or
executed** in this environment (full Rust workspace build not available here).
The change is a local reordering plus removal of one `println!`; `final_text`
remains used, so no unused-variable warning is introduced.