### PR TITLE
Fix typo in LazyCodex badge label

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/code-yeongyu/lazycodex">
-    <img src="https://img.shields.io/badge/LazyCodex-codex%20for%20no--brainers-111111?style=for-the-badge&logo=github&logoColor=white" alt="LazyCodex banner" />
+    <img src="https://img.shields.io/badge/LazyCodex-codex%20for%20no--brainrs-111111?style=for-the-badge&logo=github&logoColor=white" alt="LazyCodex banner" />
   </a>
   <a href="https://github.com/Yeachan-Heo/gajae-code">
     <img src="https://img.shields.io/badge/Gajae--Code-red--claw%20agent%20harness-B22222?style=for-the-badge&logo=github&logoColor=white" alt="Gajae-Code banner" />


### PR DESCRIPTION
Corrected a typo in the badge label for LazyCodex.

## Summary
- TBD

## Anti-slop triage
- Classification: <!-- actionable-fix | docs-only | duplicate | generated-slop | unsafe | out-of-scope | needs-maintainer-decision -->
- Evidence: <!-- issue link, repro command, failing test, docs source, or duplicate PR -->
- Non-destructive review result: <!-- merge candidate | request changes | close/defer with rationale | needs owner gate -->

## Verification
- [ ] Targeted tests/docs checks ran, or the gap is explicitly recorded.
- [ ] `git diff --check` passes.
- [ ] No live secrets, tokens, private logs, or unrelated generated churn are included.

## Resolution gate
- [ ] If this PR resolves an issue, the issue number and fix evidence are linked.
- [ ] If this PR should not merge, the rejection/defer rationale is evidence-backed and does not rely on vibes.
- [ ] I did not merge/close remote PRs or issues from an automation lane without owner approval.
