### PR TITLE
fix(sandbox): fall back to --map-auto when root-user mapping is restricted

### DIFF
--- a/rust/crates/runtime/src/sandbox.rs
+++ b/rust/crates/runtime/src/sandbox.rs
@@ -225,13 +225,9 @@ pub fn build_linux_sandbox_command(
         .iter()
         .map(|arg| arg.to_string())
         .collect();
-    args.extend([
-        "--mount".to_string(),
-        "--ipc".to_string(),
-        "--pid".to_string(),
-        "--uts".to_string(),
-        "--fork".to_string(),
-    ]);
+    // The candidates already carry the namespace flags, so the probe and the
+    // launcher share a single argument shape; only the opt-in `--net` is
+    // added here.
     if status.network_active {
         args.push("--net".to_string());
     }
@@ -287,18 +283,51 @@ fn command_exists(command: &str) -> bool {
 
 /// Candidate `unshare` user-namespace mapping options, in preference order.
 ///
-/// Most systems accept `--map-root-user` alone. On kernels or containers that
-/// block unprivileged writes to `/proc/self/uid_map` (e.g. GitHub Actions,
-/// restricted AppArmor profiles), util-linux instead delegates to the setuid
-/// `newuidmap`/`newgidmap` helpers when `--map-auto` is also present.
+/// Most systems accept `--map-root-user` alone. Some hardened containers and
+/// seccomp profiles block unprivileged writes to `/proc/self/uid_map`; there,
+/// util-linux delegates to the setuid `newuidmap`/`newgidmap` helpers when
+/// `--map-auto` is also present.
 ///
 /// That fallback therefore depends on the setuid helpers (the `uidmap`
 /// package on Debian/Ubuntu) and on the current user having a range in
 /// `/etc/subuid` and `/etc/subgid`. When either is missing, `--map-auto`
 /// fails and the startup probe rejects the candidate, keeping the plain form.
+///
+/// Each candidate is the **complete** static argument shape the launcher
+/// uses (see `build_linux_sandbox_command`): mapping flags followed by the
+/// namespace flags `--mount --ipc --pid --uts --fork`. The startup probe
+/// runs each candidate verbatim (plus a trivial program), so probe success
+/// implies launch success: on systems where the mapping works but the
+/// namespace flags are denied (e.g. AppArmor-restricted CI runners that
+/// block mount propagation in user namespaces), the probe fails and the
+/// sandbox stays disabled instead of activating a launcher that always
+/// errors.
+///
+/// `--net` is intentionally absent: it is appended only when network
+/// isolation is active (the non-default path), and probing with it would
+/// disable the sandbox on hosts that block network-namespace creation (e.g.
+/// Docker's default seccomp profile) even when network isolation is never
+/// requested.
 const UNSHARE_MAPPING_CANDIDATES: &[&[&str]] = &[
-    &["--user", "--map-root-user"],
-    &["--user", "--map-root-user", "--map-auto"],
+    &[
+        "--user",
+        "--map-root-user",
+        "--mount",
+        "--ipc",
+        "--pid",
+        "--uts",
+        "--fork",
+    ],
+    &[
+        "--user",
+        "--map-root-user",
+        "--map-auto",
+        "--mount",
+        "--ipc",
+        "--pid",
+        "--uts",
+        "--fork",
+    ],
 ];
 
 /// Probe a candidate `unshare` mapping invocation with a trivial program.
@@ -403,14 +432,45 @@ mod tests {
     fn mapping_candidates_prefer_plain_root_mapping() {
         assert!(!super::UNSHARE_MAPPING_CANDIDATES.is_empty());
         for candidate in super::UNSHARE_MAPPING_CANDIDATES {
+            // Mapping flags.
             assert!(candidate.contains(&"--user"));
             assert!(candidate.contains(&"--map-root-user"));
+            // Namespace flags the real launcher appends — the probe must
+            // exercise the full invocation shape, not just mapping flags.
+            assert!(candidate.contains(&"--mount"));
+            assert!(candidate.contains(&"--ipc"));
+            assert!(candidate.contains(&"--pid"));
+            assert!(candidate.contains(&"--uts"));
+            assert!(candidate.contains(&"--fork"));
         }
         // The plain form must be tried first; `--map-auto` is only a fallback
         // for kernels/containers that block unprivileged uid_map writes.
         assert_eq!(
             super::UNSHARE_MAPPING_CANDIDATES[0],
-            &["--user", "--map-root-user"]
+            &[
+                "--user",
+                "--map-root-user",
+                "--mount",
+                "--ipc",
+                "--pid",
+                "--uts",
+                "--fork",
+            ]
+        );
+        // The second candidate inserts `--map-auto` in the position util-linux
+        // expects (after `--map-root-user`, before the namespace flags).
+        assert_eq!(
+            super::UNSHARE_MAPPING_CANDIDATES[1],
+            &[
+                "--user",
+                "--map-root-user",
+                "--map-auto",
+                "--mount",
+                "--ipc",
+                "--pid",
+                "--uts",
+                "--fork",
+            ]
         );
     }
 

--- a/rust/crates/runtime/src/sandbox.rs
+++ b/rust/crates/runtime/src/sandbox.rs
@@ -290,8 +290,12 @@ fn command_exists(command: &str) -> bool {
 /// Most systems accept `--map-root-user` alone. On kernels or containers that
 /// block unprivileged writes to `/proc/self/uid_map` (e.g. GitHub Actions,
 /// restricted AppArmor profiles), util-linux instead delegates to the setuid
-/// `newuidmap`/`newgidmap` helpers when `--map-auto` is also present; that
-/// requires the current user to have a range in `/etc/subuid`/`/etc/subgid`.
+/// `newuidmap`/`newgidmap` helpers when `--map-auto` is also present.
+///
+/// That fallback therefore depends on the setuid helpers (the `uidmap`
+/// package on Debian/Ubuntu) and on the current user having a range in
+/// `/etc/subuid` and `/etc/subgid`. When either is missing, `--map-auto`
+/// fails and the startup probe rejects the candidate, keeping the plain form.
 const UNSHARE_MAPPING_CANDIDATES: &[&[&str]] = &[
     &["--user", "--map-root-user"],
     &["--user", "--map-root-user", "--map-auto"],

--- a/rust/crates/runtime/src/sandbox.rs
+++ b/rust/crates/runtime/src/sandbox.rs
@@ -220,15 +220,18 @@ pub fn build_linux_sandbox_command(
         return None;
     }
 
-    let mut args = vec![
-        "--user".to_string(),
-        "--map-root-user".to_string(),
+    let mut args: Vec<String> = working_unshare_mapping()
+        .unwrap_or(UNSHARE_MAPPING_CANDIDATES[0])
+        .iter()
+        .map(|arg| arg.to_string())
+        .collect();
+    args.extend([
         "--mount".to_string(),
         "--ipc".to_string(),
         "--pid".to_string(),
         "--uts".to_string(),
         "--fork".to_string(),
-    ];
+    ]);
     if status.network_active {
         args.push("--net".to_string());
     }
@@ -283,7 +286,16 @@ fn command_exists(command: &str) -> bool {
 }
 
 /// Candidate `unshare` user-namespace mapping options, in preference order.
-const UNSHARE_MAPPING_CANDIDATES: &[&[&str]] = &[&["--user", "--map-root-user"]];
+///
+/// Most systems accept `--map-root-user` alone. On kernels or containers that
+/// block unprivileged writes to `/proc/self/uid_map` (e.g. GitHub Actions,
+/// restricted AppArmor profiles), util-linux instead delegates to the setuid
+/// `newuidmap`/`newgidmap` helpers when `--map-auto` is also present; that
+/// requires the current user to have a range in `/etc/subuid`/`/etc/subgid`.
+const UNSHARE_MAPPING_CANDIDATES: &[&[&str]] = &[
+    &["--user", "--map-root-user"],
+    &["--user", "--map-root-user", "--map-auto"],
+];
 
 /// Probe a candidate `unshare` mapping invocation with a trivial program.
 fn unshare_probe(args: &[&str]) -> bool {
@@ -381,6 +393,21 @@ mod tests {
         assert!(request.network_isolation);
         assert_eq!(request.filesystem_mode, FilesystemIsolationMode::AllowList);
         assert_eq!(request.allowed_mounts, vec!["tmp"]);
+    }
+
+    #[test]
+    fn mapping_candidates_prefer_plain_root_mapping() {
+        assert!(!super::UNSHARE_MAPPING_CANDIDATES.is_empty());
+        for candidate in super::UNSHARE_MAPPING_CANDIDATES {
+            assert!(candidate.contains(&"--user"));
+            assert!(candidate.contains(&"--map-root-user"));
+        }
+        // The plain form must be tried first; `--map-auto` is only a fallback
+        // for kernels/containers that block unprivileged uid_map writes.
+        assert_eq!(
+            super::UNSHARE_MAPPING_CANDIDATES[0],
+            &["--user", "--map-root-user"]
+        );
     }
 
     #[test]

--- a/rust/crates/runtime/src/sandbox.rs
+++ b/rust/crates/runtime/src/sandbox.rs
@@ -282,6 +282,36 @@ fn command_exists(command: &str) -> bool {
         .is_some_and(|paths| env::split_paths(&paths).any(|path| path.join(command).exists()))
 }
 
+/// Candidate `unshare` user-namespace mapping options, in preference order.
+const UNSHARE_MAPPING_CANDIDATES: &[&[&str]] = &[&["--user", "--map-root-user"]];
+
+/// Probe a candidate `unshare` mapping invocation with a trivial program.
+fn unshare_probe(args: &[&str]) -> bool {
+    std::process::Command::new("unshare")
+        .args(args)
+        .arg("true")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+/// The first mapping option set that works on this machine, if any.
+///
+/// Probes are cached for the process lifetime; a missing `unshare` binary or a
+/// kernel that refuses every mapping yields `None`.
+fn working_unshare_mapping() -> Option<&'static [&'static str]> {
+    use std::sync::OnceLock;
+    static MAPPING: OnceLock<Option<&'static [&'static str]>> = OnceLock::new();
+    *MAPPING.get_or_init(|| {
+        UNSHARE_MAPPING_CANDIDATES
+            .iter()
+            .copied()
+            .find(|args| unshare_probe(args))
+    })
+}
+
 /// Check whether `unshare --user` actually works on this system.
 /// On some CI environments (e.g. GitHub Actions), the binary exists but
 /// user namespaces are restricted, causing silent failures.
@@ -292,13 +322,7 @@ fn unshare_user_namespace_works() -> bool {
         if !command_exists("unshare") {
             return false;
         }
-        std::process::Command::new("unshare")
-            .args(["--user", "--map-root-user", "true"])
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success())
+        working_unshare_mapping().is_some()
     })
 }
 


### PR DESCRIPTION
Replaces the closed #3013 (stale, conflicts with main) with a fresh rebase onto `ultraworkers:main`.

## Problem

`unshare --user --map-root-user` fails on kernels and containers that block unprivileged writes to `/proc/self/uid_map` (e.g. GitHub Actions, restricted AppArmor profiles, some container runtimes) with EPERM. As a result the sandbox silently disables itself even though a working mapping exists.

## Fix

util-linux delegates to the setuid `newuidmap`/`newgidmap` helpers when `--map-auto` is also present. Probe both candidate mappings at startup and prefer the plain form:

1. `--user --map-root-user` (works on most systems, no extra deps)
2. `--user --map-root-user --map-auto` (fallback for restricted kernels/containers)

The chosen mapping is cached and reused by both the capability probe and the launcher, so the sandbox now enables on systems where only the fallback works. The plain form stays first, so systems without `newuidmap`/`newgidmap` or a `/etc/subuid` range are unaffected.

**Note**: the `--map-auto` fallback depends on the setuid `newuidmap`/`newgidmap` helpers (the `uidmap` package on Debian/Ubuntu) and on the current user having a subuid/subgid range. The startup probe covers this dependency: when the helpers or range are missing, `unshare --map-auto` fails and the plain form is used (verified: `unshare --user --map-root-user --map-auto true` exits 127 with `failed to execute newuidmap` without the helper).

## Verification

- On a restricted host: `unshare --user --map-root-user true` fails, combined form succeeds
- `cargo test -p runtime sandbox` passes (incl. new test guarding candidate order)
- `cargo clippy` clean for the changed file
