### PR TITLE
fix: support groq compound defaults

### DIFF
--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -270,6 +270,16 @@ pub fn metadata_for_model(model: &str) -> Option<ProviderMetadata> {
             default_base_url: openai_compat::DEFAULT_OPENAI_BASE_URL,
         });
     }
+    // Groq compound systems and Groq-namespaced model ids are served through
+    // the OpenAI-compatible transport selected by OPENAI_BASE_URL.
+    if canonical.starts_with("groq/") {
+        return Some(ProviderMetadata {
+            provider: ProviderKind::OpenAi,
+            auth_env: "OPENAI_API_KEY",
+            base_url_env: "OPENAI_BASE_URL",
+            default_base_url: openai_compat::DEFAULT_OPENAI_BASE_URL,
+        });
+    }
     // Alibaba DashScope compatible-mode endpoint. Routes qwen/* and bare
     // qwen-* model names (qwen-max, qwen-plus, qwen-turbo, qwen-qwq, etc.)
     // to the OpenAI-compat client pointed at DashScope's /compatible-mode/v1.
@@ -666,11 +676,26 @@ pub fn model_token_limit(model: &str) -> Option<ModelTokenLimit> {
             max_output_tokens: 16_384,
             context_window_tokens: 256_000,
         }),
+        // Groq Llama 4 models accept tool calling but cap completions below
+        // Claw's 64k fallback heuristic. Encode the provider limit so prompts
+        // fit inside Groq's request validation and TPM budget.
+        "llama-4-scout-17b-16e-instruct" => Some(ModelTokenLimit {
+            max_output_tokens: 8_192,
+            context_window_tokens: 131_072,
+        }),
         "qwen-max" => Some(ModelTokenLimit {
             max_output_tokens: 8_192,
             context_window_tokens: 131_072,
         }),
         "qwen-plus" => Some(ModelTokenLimit {
+            max_output_tokens: 8_192,
+            context_window_tokens: 131_072,
+        }),
+        // Groq compound systems are exposed through an OpenAI-compatible API
+        // but cap completions at 8,192 output tokens. Without this metadata
+        // Claw uses its 64k fallback heuristic and the provider rejects the
+        // request before generation starts.
+        "compound" | "compound-mini" => Some(ModelTokenLimit {
             max_output_tokens: 8_192,
             context_window_tokens: 131_072,
         }),
@@ -1081,6 +1106,18 @@ mod tests {
     }
 
     #[test]
+    fn groq_prefix_routes_to_openai_not_anthropic() {
+        let meta = super::metadata_for_model("groq/compound")
+            .expect("groq/ prefix must resolve to OpenAI-compatible metadata");
+        assert_eq!(meta.provider, ProviderKind::OpenAi);
+        assert_eq!(meta.auth_env, "OPENAI_API_KEY");
+        assert_eq!(meta.base_url_env, "OPENAI_BASE_URL");
+
+        let kind = detect_provider_kind("groq/compound");
+        assert_eq!(kind, ProviderKind::OpenAi);
+    }
+
+    #[test]
     fn qwen_prefix_routes_to_dashscope_not_anthropic() {
         // User request from Discord #clawcode-get-help: web3g wants to use
         // Qwen 3.6 Plus via native Alibaba DashScope API (not OpenRouter,
@@ -1377,6 +1414,27 @@ mod tests {
             alias_limit.context_window_tokens,
             direct_limit.context_window_tokens
         );
+    }
+
+    #[test]
+    fn returns_context_window_metadata_for_groq_compound_models() {
+        let compound =
+            model_token_limit("groq/compound").expect("groq/compound should have token limits");
+        assert_eq!(compound.max_output_tokens, 8_192);
+        assert_eq!(compound.context_window_tokens, 131_072);
+
+        let compound_mini = model_token_limit("groq/compound-mini")
+            .expect("groq/compound-mini should have token limits");
+        assert_eq!(compound_mini.max_output_tokens, 8_192);
+        assert_eq!(compound_mini.context_window_tokens, 131_072);
+    }
+
+    #[test]
+    fn returns_context_window_metadata_for_groq_llama4_scout() {
+        let scout = model_token_limit("groq/meta-llama/llama-4-scout-17b-16e-instruct")
+            .expect("groq llama 4 scout should have token limits");
+        assert_eq!(scout.max_output_tokens, 8_192);
+        assert_eq!(scout.context_window_tokens, 131_072);
     }
 
     #[test]

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -12624,6 +12624,16 @@ fn resolve_cli_auth_source_for_cwd() -> Result<AuthSource, api::ApiError> {
     resolve_startup_auth_source(|| Ok(None))
 }
 
+fn model_supports_local_tools(model: &str) -> bool {
+    !matches!(
+        api::resolve_model_alias(model)
+            .rsplit('/')
+            .next()
+            .unwrap_or(model),
+        "compound" | "compound-mini"
+    )
+}
+
 impl ApiClient for AnthropicRuntimeClient {
     #[allow(clippy::too_many_lines)]
     fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
@@ -12631,15 +12641,15 @@ impl ApiClient for AnthropicRuntimeClient {
             progress_reporter.mark_model_phase();
         }
         let is_post_tool = request_ends_with_tool_result(&request);
+        let enable_local_tools = self.enable_tools && model_supports_local_tools(&self.model);
         let message_request = MessageRequest {
             model: self.model.clone(),
             max_tokens: max_tokens_for_model(&self.model),
             messages: convert_messages(&request.messages),
             system: (!request.system_prompt.is_empty()).then(|| request.system_prompt.join("\n\n")),
-            tools: self
-                .enable_tools
+            tools: enable_local_tools
                 .then(|| filter_tool_specs(&self.tool_registry, self.allowed_tools.as_ref())),
-            tool_choice: self.enable_tools.then_some(ToolChoice::Auto),
+            tool_choice: enable_local_tools.then_some(ToolChoice::Auto),
             stream: true,
             reasoning_effort: self.reasoning_effort.clone(),
             ..Default::default()
@@ -19435,6 +19445,14 @@ UU conflicted.rs",
                 assert_eq!(reasoning_effort.as_deref(), Some(value));
             }
         }
+    }
+
+    #[test]
+    fn groq_compound_disables_local_tools() {
+        assert!(!super::model_supports_local_tools("groq/compound"));
+        assert!(!super::model_supports_local_tools("groq/compound-mini"));
+        assert!(super::model_supports_local_tools("sonnet"));
+        assert!(super::model_supports_local_tools("llama-3.1-8b-instant"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route `groq/` model IDs through the OpenAI-compatible client
- add Groq token-limit metadata for compound and llama 4 scout models
- disable local tool injection for compound models and add regression coverage

## Validation
- `cargo test --manifest-path rust/Cargo.toml groq_ --workspace`
- `cargo build --manifest-path rust/Cargo.toml --release --workspace`
- `zsh -lic 'mkdir -p /Users/abdullah/tools/claw-smoke && claw --cwd /Users/abdullah/tools/claw-smoke --permission-mode read-only prompt "Reply exactly READY"'`

Conversation: https://app.warp.dev/conversation/9443f8d1-a24e-42ea-9f04-0dd8bf608859

Co-Authored-By: Oz <oz-agent@warp.dev>
